### PR TITLE
Get @binaris/ scoped packages from npmjs

### DIFF
--- a/app-testsuite/verdaccio.yaml
+++ b/app-testsuite/verdaccio.yaml
@@ -29,9 +29,6 @@ packages:
   reshuffle:
     access: $all
     publish: $all
-  '@binaris/*':
-    access: $all
-    publish: $all
   '@*/*':
     # scoped packages
     access: $all


### PR DESCRIPTION
We no longer publish packages with @binaris from reshuffle repo
Used for @binaris/spice-node-client

Continuation of #247 