### PR TITLE
Prettify LevelDB errors correctly

### DIFF
--- a/common/changes/@reshuffle/leveldb-server/feature-bug-immutable-errors_2019-09-24-05-59.json
+++ b/common/changes/@reshuffle/leveldb-server/feature-bug-immutable-errors_2019-09-24-05-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@reshuffle/leveldb-server",
+      "comment": "Correctly handle LevelDB errors",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@reshuffle/leveldb-server",
+  "email": "ariels@reshuffle.com"
+}

--- a/leveldb-server/src/db.ts
+++ b/leveldb-server/src/db.ts
@@ -80,7 +80,7 @@ export class Handler implements DBHandler {
   protected readonly writeLock = new Mutex();
   protected readonly db: LevelUp;
 
-  constructor(protected readonly dbPath: string, errorCallback?: (err: Error) => any) {
+  constructor(protected readonly dbPath: string, errorCallback?: (err: Error | undefined) => any) {
     this.db = new LevelUpCtor(new LevelDown(dbPath), errorCallback);
   }
 

--- a/leveldb-server/src/db.ts
+++ b/leveldb-server/src/db.ts
@@ -30,6 +30,13 @@ export type KeyedPatches = Array<[string, Patch[]]>;
 const NUM_PATCHES_TO_KEEP = 20;
 const DEFAULT_READ_BLOCK_TIME_MS = 50000;
 
+export class WrappedError extends Error {
+  constructor(msg: string, public readonly err: Error, public readonly debugId: string) {
+    super(msg);
+    this.stack += `\ncaused by:\n${err.stack}`;
+  }
+}
+
 export function incrVersion({ major, minor }: Version, amount: number = 1): Version {
   return { major, minor: minor + amount };
 }
@@ -72,8 +79,9 @@ export class Handler implements DBHandler {
   protected emitter = new EventEmitter();
   protected readonly writeLock = new Mutex();
   protected readonly db: LevelUp;
-  constructor(protected readonly dbPath: string) {
-    this.db = new LevelUpCtor(new LevelDown(dbPath));
+
+  constructor(protected readonly dbPath: string, errorCallback?: (err: Error) => any) {
+    this.db = new LevelUpCtor(new LevelDown(dbPath), errorCallback);
   }
 
   public async extractContext(_ctx: KoaContext): Promise<ServerOnlyContext> {
@@ -125,7 +133,7 @@ export class Handler implements DBHandler {
       return JSON.parse(val.toString());
     } catch (err) {
       if (err.notFound) return undefined;
-      throw { ...err, debugId, message: `[${debugId}] ${err.message}` };
+      throw new WrappedError(`[${debugId}] ${err.message}`, err, debugId);
     }
   }
 

--- a/leveldb-server/src/db.ts
+++ b/leveldb-server/src/db.ts
@@ -125,9 +125,7 @@ export class Handler implements DBHandler {
       return JSON.parse(val.toString());
     } catch (err) {
       if (err.notFound) return undefined;
-      err.debugId = debugId;
-      err.message = `[${debugId}] ${err.message}`;
-      throw err;
+      throw { ...err, debugId, message: `[${debugId}] ${err.message}` };
     }
   }
 

--- a/leveldb-server/src/test/client.test.ts
+++ b/leveldb-server/src/test/client.test.ts
@@ -6,18 +6,23 @@ import * as path from 'path';
 import { Handler } from '../db';
 import { setUpTests } from '@reshuffle/db-testsuite/dist/client';
 
-setUpTests<{ dbDir: string }>({
+setUpTests<{ dbDir: string, errorsOk?: boolean, errors: Error[] }>({
   async setUp() {
+    const errors: Error[] = [];
     const dbDir = await promisify(mkdtemp)(path.join(tmpdir(), 'test-state-'), 'utf8');
     return {
-      handler: new Handler(`${dbDir}/root.db`),
+      handler: new Handler(`${dbDir}/root.db`, (err) => err && errors.push(err)),
       supportsPolling: true,
       context: {
         dbDir,
+        errors,
       },
     };
   },
   async tearDown(ctx) {
+    if (!ctx.errorsOk && ctx.errors.length > 0) {
+      throw new Error(`Unexamined errors: ${ctx.errors}`);
+    }
     await rmrf(ctx.dbDir);
   },
 });


### PR DESCRIPTION
Don't touch immutable `Error`s, copy them instead.  Resulting error
looks like this:
```
Failed to invoke function { InternalServerError: [6hMvBxG47sy90hXscv-DJ] Database is not open
    at DBClient.get (/Users/ariels/Google Drive/Work/Dev/counter-class-master/node_modules/@reshuffle/interfaces-node-client/client.js:108:19)
    at process._tickCallback (internal/process/next_tick.js:68:7) name: 'InternalServerError' }

  InternalServerError: [6hMvBxG47sy90hXscv-DJ] Database is not open
      at DBClient.get (/Users/ariels/Google Drive/Work/Dev/counter-class-master/node_modules/@reshuffle/interfaces-node-client/client.js:108:19)
      at process._tickCallback (internal/process/next_tick.js:68:7)
```

Fixes #255.

Tested (see above) by manually linking and running 2 conncurrent local
servers.

However I *cannot* write a (simple) unit test: as detailed in #255,
when opening a LevelDB server fails there is a *previous* asynchronous
error that cannot (easily?) be caught an processed.  So any test fails
claiming e.g.
```
  /Users/ariels/Google Drive/Work/Dev/reshuffle/common/temp/node_modules/.registry.npmjs.org/levelup/4.2.0/node_modules/levelup/lib/levelup.js:96

  OpenError: IO error: lock /var/folders/k7/8lqpw3ws3ybd5_rm_1jvzlj00000gn/T/test-state-vSftNV/root.db/LOCK: already held by process

  /Users/ariels/Google Drive/Work/Dev/reshuffle/common/temp/node_modules/.registry.npmjs.org/levelup/4.2.0/node_modules/levelup/lib/levelup.js:96:23
  /Users/ariels/Google Drive/Work/Dev/reshuffle/common/temp/node_modules/.registry.npmjs.org/abstract-leveldown/6.1.1/node_modules/abstract-leveldown/abstract-leveldown.js:30:14
  /Users/ariels/Google Drive/Work/Dev/reshuffle/common/temp/node_modules/.registry.npmjs.org/deferred-leveldown/5.2.1/node_modules/deferred-leveldown/deferred-leveldown.js:22:21
  /Users/ariels/Google Drive/Work/Dev/reshuffle/common/temp/node_modules/.registry.npmjs.org/abstract-leveldown/6.1.1/node_modules/abstract-leveldown/abstract-leveldown.js:30:14
```
This comes straight outta the event loop, so not possible to catch.

(I *could* start the server in a separate process.  I claim this is
too much cruft for the size of this fix -- but a reviewer can change
this!)
