### PR TITLE
CR: Do literally nothing when dropping promise resolution

### DIFF
--- a/cli/src/utils/command.ts
+++ b/cli/src/utils/command.ts
@@ -65,7 +65,7 @@ export default abstract class BaseCommand extends Command {
   // debug messages.  Silences tslint "Promises must be handled
   // appropriately".  Good e.g. for wrapping analytics calls.
   protected drop<T>(p: Promise<T>, warnFn: (e: string | Error) => any = this.debug.bind(this)) {
-    p.then(() => undefined).catch(warnFn);
+    p.catch(warnFn);
   }
 
   public static flags: Parser.flags.Input<any>  = {

--- a/common/changes/reshuffle/download-analytics_2019-09-26-06-56.json
+++ b/common/changes/reshuffle/download-analytics_2019-09-26-06-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "reshuffle",
+      "type": "none"
+    }
+  ],
+  "packageName": "reshuffle",
+  "email": "ariels@reshuffle.com"
+}


### PR DESCRIPTION
I thought it would be clearer to `then` a function that does nothing,
the #266  code review proved me wrong.

Then I forgot to include it in the fixes.  Sorry.