### PR TITLE
Measure stage timings during deploy

### DIFF
--- a/common/changes/reshuffle/timedeploy_2019-10-03-07-52.json
+++ b/common/changes/reshuffle/timedeploy_2019-10-03-07-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "reshuffle",
+      "comment": "Measure stage timings during deploy",
+      "type": "minor"
+    }
+  ],
+  "packageName": "reshuffle",
+  "email": "ariels@reshuffle.com"
+}

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -215,7 +215,7 @@ packages:
       '@babel/types': 7.6.1
       convert-source-map: 1.6.0
       debug: 4.1.1
-      json5: 2.1.0
+      json5: 2.1.1
       lodash: 4.17.15
       resolve: 1.12.0
       semver: 5.7.1
@@ -1010,7 +1010,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==
-  /@types/cookies/0.7.3:
+  /@types/cookies/0.7.4:
     dependencies:
       '@types/connect': 3.4.32
       '@types/express': 4.17.1
@@ -1018,7 +1018,7 @@ packages:
       '@types/node': 12.7.9
     dev: false
     resolution:
-      integrity: sha512-NEkYn8pNsYZIxf3ZrjdPoeyueiPc0RbQClUpTwmdHkpmQQ8iDAlQYKpabuegHy7BJcqTteSTkhURMEs9ZxyEWg==
+      integrity: sha512-oTGtMzZZAVuEjTwCjIh8T8FrC8n/uwy+PG0yTvQcdZ7etoel7C7/3MSd7qrukENTgQtotG7gvBlBojuVs7X5rw==
   /@types/deep-freeze/0.1.2:
     dev: false
     resolution:
@@ -1156,7 +1156,7 @@ packages:
   /@types/koa/2.0.50:
     dependencies:
       '@types/accepts': 1.3.5
-      '@types/cookies': 0.7.3
+      '@types/cookies': 0.7.4
       '@types/http-assert': 1.5.1
       '@types/keygrip': 1.0.1
       '@types/koa-compose': 3.2.4
@@ -3225,7 +3225,7 @@ packages:
     dev: false
     resolution:
       integrity: sha1-4rPZG1Su1nLzCdlQ0VSFD6EdTzc=
-  /es-abstract/1.14.2:
+  /es-abstract/1.15.0:
     dependencies:
       es-to-primitive: 1.2.0
       function-bind: 1.1.1
@@ -3241,7 +3241,7 @@ packages:
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==
+      integrity: sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==
   /es-to-primitive/1.2.0:
     dependencies:
       is-callable: 1.1.4
@@ -3995,7 +3995,7 @@ packages:
     dev: false
     resolution:
       integrity: sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
-  /handlebars/4.4.0:
+  /handlebars/4.4.2:
     dependencies:
       neo-async: 2.6.1
       optimist: 0.6.1
@@ -4007,7 +4007,7 @@ packages:
     optionalDependencies:
       uglify-js: 3.6.0
     resolution:
-      integrity: sha512-xkRtOt3/3DzTKMOt3xahj2M/EqNhY988T+imYSlMgs5fVhLN2fmKVVj0LtEGmb+3UUYV5Qmm1052Mm3dIQxOvw==
+      integrity: sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==
   /har-schema/2.0.0:
     dev: false
     engines:
@@ -4841,7 +4841,7 @@ packages:
       integrity: sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==
   /istanbul-reports/2.2.6:
     dependencies:
-      handlebars: 4.4.0
+      handlebars: 4.4.2
     dev: false
     engines:
       node: '>=6'
@@ -5357,7 +5357,7 @@ packages:
     dev: false
     resolution:
       integrity: sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
-  /json5/2.1.0:
+  /json5/2.1.1:
     dependencies:
       minimist: 1.2.0
     dev: false
@@ -5365,7 +5365,7 @@ packages:
       node: '>=6'
     hasBin: true
     resolution:
-      integrity: sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
+      integrity: sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==
   /jsonfile/4.0.0:
     dev: false
     optionalDependencies:
@@ -6182,10 +6182,10 @@ packages:
     optional: true
     resolution:
       integrity: sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
-  /nanoid/2.1.1:
+  /nanoid/2.1.2:
     dev: false
     resolution:
-      integrity: sha512-0YbJdaL4JFoejIOoawgLcYValFGJ2iyUuVDIWL3g8Es87SSOWFbWdRUMV3VMSiyPs3SQ3QxCIxFX00q5DLkMCw==
+      integrity: sha512-q0iKJHcLc9rZg/qtJ/ioG5s6/5357bqvkYCpqXJxpcyfK7L5us8+uJllZosqPWou7l6E1lY2Qqoq5ce+AMbFuQ==
   /nanomatch/1.2.13:
     dependencies:
       arr-diff: 4.0.0
@@ -6616,7 +6616,7 @@ packages:
   /object.getownpropertydescriptors/2.0.3:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.14.2
+      es-abstract: 1.15.0
     dev: false
     engines:
       node: '>= 0.8'
@@ -7370,7 +7370,7 @@ packages:
     dependencies:
       debug: 4.1.1
       js-yaml: 3.13.1
-      json5: 2.1.0
+      json5: 2.1.1
       object-assign: 4.1.1
       object-keys: 1.1.1
       path-exists: 3.0.0
@@ -8167,7 +8167,7 @@ packages:
     dependencies:
       async-mutex: 0.1.4
       defer-promise: 2.0.1
-      nanoid: 2.1.1
+      nanoid: 2.1.2
       stream-buffers: 3.0.2
       streamsearch: 0.1.2
     dev: false
@@ -8976,7 +8976,7 @@ packages:
     dependencies:
       '@types/minimatch': 3.0.3
       fs-extra: 8.1.0
-      handlebars: 4.4.0
+      handlebars: 4.4.2
       highlight.js: 9.15.10
       lodash: 4.17.15
       marked: 0.7.0
@@ -9596,7 +9596,7 @@ packages:
       ava: 2.4.0
       koa: 2.8.2
       koa-router: 7.4.0
-      nanoid: 2.1.1
+      nanoid: 2.1.2
       ramda: 0.26.1
       tslint: /tslint/5.20.0/typescript@3.6.3
       typescript: 3.6.3
@@ -9696,7 +9696,7 @@ packages:
       koa: 2.8.2
       leveldown: 5.2.1
       levelup: 4.3.0
-      nanoid: 2.1.1
+      nanoid: 2.1.2
       ramda: 0.26.1
       rmfr: 2.0.0
       tslint: /tslint/5.20.0/typescript@3.6.3
@@ -9740,7 +9740,7 @@ packages:
       lodash: 4.17.15
       logform: 2.1.2
       mkdirp: 0.5.1
-      nanoid: 2.1.1
+      nanoid: 2.1.2
       nodemon: 1.19.3
       rimraf: 2.7.1
       tslint: /tslint/5.20.0/typescript@3.6.3


### PR DESCRIPTION
- Output on debug, need to set e.g. `DEBUG` envariable to match
  `reshuffle:deploy`.
- Last output so all timings appear together -- useful if you just
  `DEBUG=\*` before the deploy command.
- OClif actually measures times between `debug` calls.  But using that
  means you need to be very careful how you set `DEBUG` (i.e. it's
  useful as a by-product when logging debug, less if your intent is to
  measure performance).

Output looks like this:
```
flutterby:counter-class ariels$ DEBUG='reshuffle:deploy' ~/Dev/reshuffle/cli/bin/run deploy
Building and bundling your app! This may take a few moments, please wait

> counter-class@0.1.2 build /Users/ariels/Google Drive/Work/Dev/counter-class
> react-scripts build

Creating an optimized production build...
Compiled successfully.

File sizes after gzip:

  41.56 KB  build/static/js/2.258bc445.chunk.js
  1 KB      build/static/js/main.1edd228b.chunk.js
  762 B     build/static/js/runtime~main.a8a9905a.js
  438 B     build/static/css/main.8f98742a.chunk.css

The project was built assuming it is hosted at the server root.
You can control this with the homepage field in your package.json.
For example, add this to build it for GitHub Pages:

  "homepage" : "http://myname.github.io/myapp",

The build folder is ready to be deployed.
You may serve it with a static server:

  npm install -g serve
  serve -s build

Find out more about deployment here:

  https://bit.ly/CRA-deploy

Preparing backend...
Successfully compiled 2 files with Babel.
Uploading your assets! This may take a few moments, please wait
Preparing your cloud deployment! This may take a few moments, please wait
Project successfully deployed! Your project is now available at: invitingbass32.reshuffle.app
  reshuffle:deploy timing { stage: 'authenticate', durationSecs: 0.007187029 } +0ms
  reshuffle:deploy timing { stage: 'get project', durationSecs: 0.0026512970000000004 } +3ms
  reshuffle:deploy timing { stage: 'build', durationSecs: 9.853440088 } +0ms
  reshuffle:deploy timing { stage: 'zip', durationSecs: 1.665271517 } +0ms
  reshuffle:deploy timing { stage: 'upload', durationSecs: 2.996489945 } +0ms
  reshuffle:deploy timing { stage: 'remove staging', durationSecs: 0.24740096099999997 } +1ms
  reshuffle:deploy timing { stage: 'register app on local',
  durationSecs: 0.00008471700000000001 } +0ms
  reshuffle:deploy timing { stage: 'deploy', durationSecs: 4.996180076 } +0ms
```