### PR TITLE
Download into local directory, not tmp

### DIFF
--- a/cli/src/commands/download.ts
+++ b/cli/src/commands/download.ts
@@ -3,7 +3,6 @@ import * as path from 'path';
 import * as tar from 'tar';
 import { rename, mkdtemp } from 'mz/fs';
 import { remove } from 'fs-extra';
-import { tmpdir } from 'os';
 import fetch, { Response } from 'node-fetch';
 import { spawn } from '@binaris/utils-subprocess';
 import Command from '../utils/command';
@@ -99,7 +98,7 @@ export default class Download extends Command {
       action: 'download::download',
       label: appName,
     }]));
-    const stagingDir = await mkdtemp(path.resolve(tmpdir(), 'reshuffle-download-'), { encoding: 'utf8' });
+    const stagingDir = await mkdtemp(path.resolve('.reshuffle-download-'), { encoding: 'utf8' });
     const extract = tar.extract({ cwd: stagingDir });
     const verboseLog = (type: string, err: Error) => {
       if (verbose) {

--- a/common/changes/reshuffle/feature-download-no-tmp_2019-10-06-10-43.json
+++ b/common/changes/reshuffle/feature-download-no-tmp_2019-10-06-10-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "reshuffle",
+      "comment": "Download directly under CWD, not /tmp/.  Fixes issues on cross-device moves and writability of /tmp/.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "reshuffle",
+  "email": "ariels@reshuffle.com"
+}


### PR DESCRIPTION
Fixes these issues (due to @vogre, no actual user-facing issues filed):
1. When `/tmp/` (or whatever temporary directory is used) is on
       another directory, there is _no_ atomic rename from the temporary
       directory into the current directory.
2. Write permissions on the temporary directory were needed.

This may fix (or at least aid) using `[cli] deploy` on Windows.
