### PR TITLE
Add --exclude-packages flag to exclude some packages from auto-update 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           command: scripts/generate_interfaces
       - run:
           name: Update npm dependencies
-          command: node common/scripts/install-run.js rush-update@latest rush-update -x @types/node --repo-owner binaris --repo-name shiftjs --pr-reviewers michaeladda
+          command: node common/scripts/install-run.js rush-update@latest rush-update -x @types/node -e @reshuffle/interfaces-koa-server -e @reshuffle/interfaces-node-client -e @reshuffle/interfaces --repo-owner binaris --repo-name shiftjs --pr-reviewers michaeladda
 workflows:
   version: 2
   commit:

--- a/common/changes/rush-update/rush-update-exclude-packages_2019-10-22-12-06.json
+++ b/common/changes/rush-update/rush-update-exclude-packages_2019-10-22-12-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "rush-update",
+      "comment": "Allow skipping packages in rush-update",
+      "type": "patch"
+    }
+  ],
+  "packageName": "rush-update",
+  "email": "vladimir@reshuffle.com"
+}

--- a/tools/rush-update/src/cli.ts
+++ b/tools/rush-update/src/cli.ts
@@ -18,6 +18,13 @@ const { argv } = yargs
     array: true,
     default: [],
   })
+  .option('exclude-packages', {
+    describe: 'Packages to exclude from update',
+    alias: 'e',
+    type: 'string',
+    array: true,
+    default: [],
+  })
   .option('branch', {
     describe: 'Branch for commiting changes',
     alias: 'b',
@@ -97,6 +104,7 @@ const {
   branch,
   'commit-message': commitMessage,
   'change-commit-message': changeCommitMessage,
+  'exclude-packages': excludePackages,
   'gh-username': ghUsername,
   'gh-apikey': ghApikey,
   'repo-owner': repoOwner,
@@ -128,6 +136,7 @@ main({
   prTitle,
   prBody,
   prReviewers,
+  excludePackages,
 }).catch((error) => {
   console.error(error);
   process.exit(1);

--- a/tools/rush-update/src/main.ts
+++ b/tools/rush-update/src/main.ts
@@ -28,6 +28,7 @@ export default async function main({
   prTitle,
   prBody,
   prReviewers,
+  excludePackages,
 }: {
   ncuParams?: Partial<NCUParams>
   noCommit?: boolean,
@@ -45,8 +46,9 @@ export default async function main({
   prTitle?: string,
   prBody?: string,
   prReviewers?: string[],
+  excludePackages?: string[],
 }) {
-  const projectFolders = await getProjectFolders();
+  const projectFolders = await getProjectFolders(excludePackages || []);
   const shouldUpdateShrinkwrapFile = await updatePackageFiles(projectFolders, ncuParams || {});
   if (!shouldUpdateShrinkwrapFile) {
     console.info('All dependencies are up to date!');

--- a/tools/rush-update/src/rush.ts
+++ b/tools/rush-update/src/rush.ts
@@ -7,6 +7,7 @@ import { execSync } from 'child_process';
 interface RushConfig {
   rushVersion: string;
   projects: Array<{
+    packageName: string;
     projectFolder: string,
   }>;
 }
@@ -19,9 +20,10 @@ const getRushConfig = once(async () => {
 });
 
 const getRushVersion = once(() => getRushConfig().then((cfg) => cfg.rushVersion));
-export const getProjectFolders = once(() => getRushConfig()
-  .then(({projects}) => projects.map((p) => p.projectFolder))
-);
+export const getProjectFolders = async (excludePackages: string[]) => {
+  const { projects } = await getRushConfig();
+  return projects.filter((p) => !excludePackages.includes(p.packageName)).map((p) => p.projectFolder);
+};
 
 export async function updateRushShrinkwrapFile(): Promise<void> {
   const { installAndRun } = await importInstallRunScript();


### PR DESCRIPTION
Exclude concord generated/generating packages from auto-update

To allow PRs like #284 to work again.