### PR TITLE
Lock cypress version to 3.4.1

### DIFF
--- a/app-testsuite/src/run.ts
+++ b/app-testsuite/src/run.ts
@@ -283,7 +283,7 @@ async function main() {
     const app = await createApp(testDir);
     await app.run(process.env.APP_E2E_RUN_MODE || 'local', async (baseUrl) => {
       log('Running tests');
-      await spawn('npx', ['cypress', 'run'], {
+      await spawn('npx', ['cypress@3.4.1', 'run'], {
         cwd: path.resolve(__dirname, '..'),
         stdio: 'inherit',
         shell,


### PR DESCRIPTION
Cypress expects to be installed as root for sandbox permissions
npx only works with node user in testing.Dockerfile
Consider switching to cypress docker image when available