### PR TITLE
Use an explicit configFile for babel backend config

### DIFF
--- a/cli/src/commands/deploy.ts
+++ b/cli/src/commands/deploy.ts
@@ -78,6 +78,9 @@ export default class Deploy extends Command {
       });
 
       await spawn(escapeWin32(pathResolve(projectDir, 'node_modules', '.bin', 'babel')), [
+        '--no-babelrc',
+        '--config-file',
+        pathResolve(__dirname, '../../lib/utils/babelBackendConfig.js'),
         '--plugins',
         ['@babel/plugin-transform-modules-commonjs',
           'module:@reshuffle/code-transform'].join(','),

--- a/cli/src/utils/babelBackendConfig.ts
+++ b/cli/src/utils/babelBackendConfig.ts
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/common/changes/@reshuffle/local-proxy/babel-backend-config_2019-11-07-19-22.json
+++ b/common/changes/@reshuffle/local-proxy/babel-backend-config_2019-11-07-19-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@reshuffle/local-proxy",
+      "comment": "Do not load default babel config for backend transiplation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@reshuffle/local-proxy",
+  "email": "vladimir@reshuffle.com"
+}

--- a/common/changes/reshuffle/babel-backend-config_2019-11-07-20-26.json
+++ b/common/changes/reshuffle/babel-backend-config_2019-11-07-20-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "reshuffle",
+      "comment": "Do not use babelrc and babel config for backend transpilation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "reshuffle",
+  "email": "vladimir@reshuffle.com"
+}

--- a/local-proxy/src/babelBackendConfig.ts
+++ b/local-proxy/src/babelBackendConfig.ts
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/local-proxy/src/server.ts
+++ b/local-proxy/src/server.ts
@@ -112,6 +112,7 @@ async function transpileAndCopy() {
     babelOptions: {
       sourceMaps: true,
       configFile: __dirname + '/babelBackendConfig.js',
+      babelrc: false,
       plugins: [
         '@babel/plugin-transform-modules-commonjs',
         'module:@reshuffle/code-transform',

--- a/local-proxy/src/server.ts
+++ b/local-proxy/src/server.ts
@@ -111,6 +111,7 @@ async function transpileAndCopy() {
     },
     babelOptions: {
       sourceMaps: true,
+      configFile: __dirname + '/babelBackendConfig.js',
       plugins: [
         '@babel/plugin-transform-modules-commonjs',
         'module:@reshuffle/code-transform',


### PR DESCRIPTION
Usually a non-CRA front-end project will contain a babel.config.js which
front-end oriented configuration (e.g. regenerator-runtime).

This only provides an empty configuration, could be extended in the
future to allow custom backend babel configuration (e.g. more plugins)