### PR TITLE
Enable source map support

### DIFF
--- a/cli/src/commands/deploy.ts
+++ b/cli/src/commands/deploy.ts
@@ -81,6 +81,8 @@ export default class Deploy extends Command {
         '--no-babelrc',
         '--config-file',
         pathResolve(__dirname, '../../lib/utils/babelBackendConfig.js'),
+        '--source-maps',
+        'true',
         '--plugins',
         ['@babel/plugin-transform-modules-commonjs',
           'module:@reshuffle/code-transform'].join(','),

--- a/common/changes/@reshuffle/local-proxy/source-map-support_2019-11-11-07-35.json
+++ b/common/changes/@reshuffle/local-proxy/source-map-support_2019-11-11-07-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@reshuffle/local-proxy",
+      "type": "none"
+    }
+  ],
+  "packageName": "@reshuffle/local-proxy",
+  "email": "vladimir@reshuffle.com"
+}

--- a/common/changes/@reshuffle/server-function/source-map-support_2019-11-07-22-51.json
+++ b/common/changes/@reshuffle/server-function/source-map-support_2019-11-07-22-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@reshuffle/server-function",
+      "comment": "Enable source maps in exceptions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@reshuffle/server-function",
+  "email": "vladimir@reshuffle.com"
+}

--- a/common/changes/reshuffle/source-map-support_2019-11-07-22-51.json
+++ b/common/changes/reshuffle/source-map-support_2019-11-07-22-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "reshuffle",
+      "comment": "Generate source maps",
+      "type": "patch"
+    }
+  ],
+  "packageName": "reshuffle",
+  "email": "vladimir@reshuffle.com"
+}

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -57,6 +57,7 @@ dependencies:
   '@types/rimraf': 2.0.3
   '@types/rmfr': 2.0.0
   '@types/sinon': 7.5.0
+  '@types/source-map-support': 0.5.0
   '@types/tail': 1.2.2
   '@types/tar': 4.0.3
   '@types/uuid': 3.4.6
@@ -112,6 +113,7 @@ dependencies:
   rxjs: 6.5.3
   sinon: 7.5.0
   sleep-promise: 8.0.1
+  source-map-support: 0.5.16
   specshell: 0.0.3
   tail: 2.0.3
   tar: 5.0.5
@@ -1300,6 +1302,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-NyzhuSBy97B/zE58cDw4NyGvByQbAHNP9069KVSgnXt/sc0T6MFRh0InKAeBVHJWdSXG1S3+PxgVIgKo9mTHbw==
+  /@types/source-map-support/0.5.0:
+    dependencies:
+      '@types/node': 12.12.6
+    dev: false
+    resolution:
+      integrity: sha512-OrnAz5K5dXDgMdeRRoXIjDAvkodQ9ESvVJCyzrhzUJKmCkXgmYx/KLUBcVFe5eS4FiohfcY7YPxsdkmSwJz9wA==
   /@types/stack-utils/1.0.1:
     dev: false
     resolution:
@@ -9965,13 +9973,15 @@ packages:
       '@types/express': 4.17.2
       '@types/lodash.once': 4.1.6
       '@types/node': 10.17.4
+      '@types/source-map-support': 0.5.0
       express: 4.17.1
       lodash.once: 4.1.1
+      source-map-support: 0.5.16
       typescript: 3.7.2
     dev: false
     name: '@rush-temp/server-function'
     resolution:
-      integrity: sha512-QBhNffFf/av0aJqebAlLS7l4wSmXIJlaiKn7hAKptTyKEwpZwOL5Tkwp076gNIzWLHCTlzpO+uxrz5G4m3Rj+Q==
+      integrity: sha512-z//xxJ+QhHlZeGiR3Z0LwKrx1P/+5vMiFF1TjC2cCgvbzldgCKo3YwSs0yTfe2ovvs1qmiJAcwSJk6DWMGB1WA==
       tarball: 'file:projects/server-function.tgz'
     version: 0.0.0
   'file:projects/subscriptions.tgz':
@@ -10066,6 +10076,7 @@ specifiers:
   '@types/rimraf': ^2.0.3
   '@types/rmfr': ^2.0.0
   '@types/sinon': ^7.5.0
+  '@types/source-map-support': ^0.5.0
   '@types/tail': ^1.2.2
   '@types/tar': ^4.0.3
   '@types/uuid': ^3.4.6
@@ -10121,6 +10132,7 @@ specifiers:
   rxjs: ^6.5.3
   sinon: ^7.5.0
   sleep-promise: ^8.0.1
+  source-map-support: ^0.5.16
   specshell: ^0.0.3
   tail: ^2.0.3
   tar: ^5.0.5

--- a/local-proxy/package.json
+++ b/local-proxy/package.json
@@ -7,7 +7,8 @@
   "description": "",
   "main": "dist/index.js",
   "scripts": {
-    "build": "rm -rf dist/ && tsc",
+    "build": "rm -rf dist/ && tsc && cp src/test/fixture/backend/testStackTrace.js dist/test/fixture/backend",
+    "build:watch": "tsc && cp src/test/fixture/backend/testStackTrace.js dist/test/fixture/backend && tsc -w",
     "lint": "tslint -c ../common/tslint.yml -p .",
     "test": "ava -v dist/test/*.test.js"
   },

--- a/local-proxy/src/missing.d.ts
+++ b/local-proxy/src/missing.d.ts
@@ -1,8 +1,8 @@
 declare module 'nodemon' {
   import { EventEmitter } from 'events';
-  // export default function nodemon(options: any): void;
+  // export default function nodemon(options: any): Nodemon;
   interface Nodemon extends EventEmitter {
-    (options: any): void;
+    (options: any): Nodemon;
   }
 
   const nodemon: Nodemon;

--- a/local-proxy/src/test/errorHandler.test.ts
+++ b/local-proxy/src/test/errorHandler.test.ts
@@ -1,0 +1,19 @@
+import anyTest, { TestInterface } from 'ava';
+import { setupTestHooks, LocalProxyTestInterface } from './setupHooks';
+import got from 'got';
+
+const test = anyTest as TestInterface<LocalProxyTestInterface>;
+setupTestHooks(test);
+
+test('error invoke', async (t) => {
+  await t.throwsAsync(got.post(`http://127.0.0.1:${t.context.port}/invoke`, {
+    headers: {},
+    body: { path: 'testStackTrace.js', args: [], handler: 'testStackTrace', },
+    json: true,
+  }), /Internal Server Error/);
+  const stderr = t.context.stderr.join('\n');
+  // we are testing that the original file uses line 3 (not line 9)
+  // additional check is that we are not seeing a '/.reshuffle/' segment in the path
+  // TODO: we are using js -> js babel transform since ts -> js -> js source maps are not preserved
+  t.assert(/\.reshuffle-local-proxy-[^/]*\/backend\/testStackTrace\.js:3:9/.test(stderr));
+});

--- a/local-proxy/src/test/fixture/backend/testStackTrace.js
+++ b/local-proxy/src/test/fixture/backend/testStackTrace.js
@@ -1,0 +1,4 @@
+// @expose
+export async function testStackTrace() {
+  throw new Error('ErrorWithStack');
+}

--- a/server-function/package.json
+++ b/server-function/package.json
@@ -17,11 +17,13 @@
   "dependencies": {
     "@types/express": "^4.17.2",
     "express": "^4.17.1",
-    "lodash.once": "^4.1.1"
+    "lodash.once": "^4.1.1",
+    "source-map-support": "^0.5.16"
   },
   "devDependencies": {
     "@types/lodash.once": "^4.1.6",
     "@types/node": "^10.14.13",
+    "@types/source-map-support": "^0.5.0",
     "typescript": "^3.7.2"
   }
 }

--- a/server-function/src/invoke.ts
+++ b/server-function/src/invoke.ts
@@ -48,7 +48,7 @@ export function getInvokeHandler(backendDir: string): ExpressHandler {
       return res.status(200).json(response);
     } catch (error) {
       // tslint:disable-next-line:no-console
-      console.error('Failed to invoke handler', { error });
+      console.error('Failed to invoke handler', error);
       return res.status(500).json({ error: 'Failed to invoke' });
     }
   };

--- a/server-function/src/serveBinaris.ts
+++ b/server-function/src/serveBinaris.ts
@@ -5,6 +5,9 @@ import http from 'http';
 import once from 'lodash.once';
 import { getHTTPHandler } from './handler';
 import { getInvokeHandler } from './invoke';
+import sourceMapSupport from 'source-map-support';
+// not handling uncaughtException - both local-proxy and runtime expected to handle them
+sourceMapSupport.install({ handleUncaughtExceptions: false, environment: 'node' });
 
 const backendDir = pathResolve('./backend');
 const buildDir = pathResolve('./build');


### PR DESCRIPTION
This change puts the source-map-support in the uploaded serveBinaris
file, so that the support is enabled in both local and remote runtimes

The price of this change is upload of source-map(-support) which adds
944K (230K compressed) to the upload