### PR TITLE
Bump version to 0.1.0

### DIFF
--- a/common/changes/@reshuffle/code-transform/bump-semver_2019-11-11-22-03.json
+++ b/common/changes/@reshuffle/code-transform/bump-semver_2019-11-11-22-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@reshuffle/code-transform",
+      "comment": "Bump to 0.1.0",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@reshuffle/code-transform",
+  "email": "vladimir@reshuffle.com"
+}

--- a/common/changes/@reshuffle/db-testsuite/bump-semver_2019-11-11-22-03.json
+++ b/common/changes/@reshuffle/db-testsuite/bump-semver_2019-11-11-22-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@reshuffle/db-testsuite",
+      "comment": "Bump to 0.1.0",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@reshuffle/db-testsuite",
+  "email": "vladimir@reshuffle.com"
+}

--- a/common/changes/@reshuffle/fetch-runtime/bump-semver_2019-11-11-22-03.json
+++ b/common/changes/@reshuffle/fetch-runtime/bump-semver_2019-11-11-22-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@reshuffle/fetch-runtime",
+      "comment": "Bump to 0.1.0",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@reshuffle/fetch-runtime",
+  "email": "vladimir@reshuffle.com"
+}

--- a/common/changes/@reshuffle/leveldb-server/bump-semver_2019-11-11-22-03.json
+++ b/common/changes/@reshuffle/leveldb-server/bump-semver_2019-11-11-22-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@reshuffle/leveldb-server",
+      "comment": "Bump to 0.1.0",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@reshuffle/leveldb-server",
+  "email": "vladimir@reshuffle.com"
+}

--- a/common/changes/@reshuffle/server-function/bump-semver_2019-11-11-22-06.json
+++ b/common/changes/@reshuffle/server-function/bump-semver_2019-11-11-22-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@reshuffle/server-function",
+      "comment": "Bump to 0.1.0",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@reshuffle/server-function",
+  "email": "vladimir@reshuffle.com"
+}


### PR DESCRIPTION
Allow releasing semver compatible versions without releasing 1.0.0 yet

Instead of #312 