### PR TITLE
Clearly report backend misconfiguration

### DIFF
--- a/common/changes/@reshuffle/react-auth/feature-better-_handler-error-message_2019-11-21-08-41.json
+++ b/common/changes/@reshuffle/react-auth/feature-better-_handler-error-message_2019-11-21-08-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@reshuffle/react-auth",
+      "comment": "Clearly describe missing backend error",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@reshuffle/react-auth",
+  "email": "ariels@reshuffle.com"
+}

--- a/react-auth/src/index.tsx
+++ b/react-auth/src/index.tsx
@@ -47,6 +47,9 @@ export const AuthProvider: FC = ({ children }) => {
     if (!req.ok) {
       throw new Error(`Failed to get /whoami ${req.statusText}`);
     }
+    if (req.headers.get('content-type') !== 'application/json') {
+      throw new Error(`Failed to GET /whoami JSON data: backend may be missing _handler.js.`);
+    }
     return req.json();
   }, []);
   return (

--- a/react-auth/src/index.tsx
+++ b/react-auth/src/index.tsx
@@ -48,7 +48,7 @@ export const AuthProvider: FC = ({ children }) => {
       throw new Error(`Failed to get /whoami ${req.statusText}`);
     }
     if (req.headers.get('content-type') !== 'application/json') {
-      throw new Error(`Failed to GET /whoami JSON data: backend may be missing _handler.js.`);
+      throw new Error('Failed to GET /whoami JSON data: backend may be missing _handler.js.');
     }
     return req.json();
   }, []);


### PR DESCRIPTION
When the backend is misconfigured and `_handler` is missing the
default backend does not give a JSON response.  Fail accordingly and
print a readable error message.

This is end-user-visible, of course -- but so is the existing behavior of
printing
```
SyntaxError: Unexpected token < in JSON at position 0
```
