### PR TITLE
Support per-domain auth strategies

### DIFF
--- a/common/changes/@reshuffle/passport/auth-multiple-strategies_2019-12-01-06-04.json
+++ b/common/changes/@reshuffle/passport/auth-multiple-strategies_2019-12-01-06-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@reshuffle/passport",
+      "comment": "Support strategies for multiple domains",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@reshuffle/passport",
+  "email": "vladimir@reshuffle.com"
+}

--- a/passport/src/auth-handler.ts
+++ b/passport/src/auth-handler.ts
@@ -96,9 +96,11 @@ function createOnCallback(domain: string): express.Handler {
   return (req, res, next) => {
     passport.authenticate(`auth0-${domain}`, (err, user, _info, _extra) => {
       if (err) { return next(err); }
+      // TODO: redirecting to /login, a misconfiguration causes a confusing redirect loop
       if (!user) { return res.redirect('/login'); }
       req.logIn(user, (loginErr) => {
-        if (err) { return next(loginErr); }
+        // loginErr usually indicates a failure to serialize when using a session store
+        if (loginErr) { return next(loginErr); }
         res.redirect(req.session?.returnTo || '/');
         delete req.session?.returnTo;
       });

--- a/passport/src/auth-handler.ts
+++ b/passport/src/auth-handler.ts
@@ -8,11 +8,7 @@ import { URLSearchParams } from 'url';
 
 const strategies = makeStrategies();
 for (const { domain, strategy } of strategies) {
-  if (isFake(strategy)) {
-    passport.use(strategy);
-  } else {
-    passport.use(`auth0-${domain}`, strategy);
-  }
+  passport.use(isFake(strategy) ? 'fake' : `auth0-${domain}`, strategy);
 }
 
 passport.serializeUser((user, cb) => cb(null, user));
@@ -151,7 +147,7 @@ function createPerDomainAuth(domain: string, strategy: passport.Strategy) {
     router.post(
       '/login',
       bodyParser.urlencoded({ extended: true }),
-      passport.authenticate('local', { failureRedirect: '/login' }),
+      passport.authenticate('fake', { failureRedirect: '/login' }),
       (req, res) => {
         res.redirect(req.session?.returnTo || '/');
         delete req.session?.returnTo;

--- a/passport/src/auth-handler.ts
+++ b/passport/src/auth-handler.ts
@@ -1,10 +1,18 @@
-import { makeStrategies, isFake } from './strategy';
+import { makeStrategy, makeFakeLocalStrategy, isFake } from './strategy';
 
 import express from 'express';
 import session from 'cookie-session';
 import passport from 'passport';
 import bodyParser from 'body-parser';
 import { URLSearchParams } from 'url';
+
+function makeStrategies() {
+  if (process.env.NODE_ENV === 'production' || process.env.OAUTH_CLIENT_ID) {
+    const domains = process.env.RESHUFFLE_APPLICATION_DOMAINS!.split(',');
+    return domains.map((d) => ({ domain: d, strategy: makeStrategy(d) }));
+  }
+  return [{ domain: '*', strategy: makeFakeLocalStrategy() }];
+}
 
 const strategies = makeStrategies();
 for (const { domain, strategy } of strategies) {

--- a/passport/src/strategy.ts
+++ b/passport/src/strategy.ts
@@ -49,17 +49,8 @@ class FakeLocalStrategy extends LocalStrategy {
   // Just inherit the constructor from LocalStrategy.
 }
 
-export function makeStrategies() {
-  if (process.env.NODE_ENV === 'production' || process.env.OAUTH_CLIENT_ID) {
-    validateEnv();
-    const domains = process.env.RESHUFFLE_APPLICATION_DOMAINS!.split(',');
-    return domains.map((d) => ({ domain: d, strategy: makeStrategy(d) }));
-  } else {
-    return [{ domain: '*', strategy: makeFakeLocalStrategy() }];
-  }
-}
-
-function makeStrategy(appDomain: string) {
+export function makeStrategy(appDomain: string) {
+  validateEnv();
   return new Auth0Strategy({
     clientID: process.env.OAUTH_CLIENT_ID!,
     clientSecret: process.env.OAUTH_CLIENT_SECRET!,
@@ -69,7 +60,7 @@ function makeStrategy(appDomain: string) {
 
 }
 
-function makeFakeLocalStrategy() {
+export function makeFakeLocalStrategy() {
   return new FakeLocalStrategy({
     usernameField: 'username',
     passwordField: 'password',


### PR DESCRIPTION
Attempting to use the module without matching the domain name changes
the behavior to 404, since we don't fallback to a default domain - and
for security purposes probably shouldn't