### PR TITLE
Update packages

### DIFF
--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -16,8 +16,6 @@ dependencies:
   '@oclif/plugin-help': 2.2.1
   '@oclif/tslint': 3.1.1
   '@octokit/rest': 16.35.0
-  '@reshuffle/interfaces-koa-server': 0.5.1
-  '@reshuffle/interfaces-node-client': 0.5.1
   '@rush-temp/app-testsuite': 'file:projects/app-testsuite.tgz'
   '@rush-temp/auth': 'file:projects/auth.tgz'
   '@rush-temp/code-transform': 'file:projects/code-transform.tgz'
@@ -136,7 +134,7 @@ dependencies:
   tar: 5.0.5
   terminal-link: 2.0.0
   testdouble: 3.12.4
-  ts-node: 8.5.3
+  ts-node: 8.5.4
   tsdx: 0.11.0
   tslib: 1.10.0
   tslint: 5.20.1
@@ -188,6 +186,26 @@ packages:
       source-map: 0.5.7
     dev: false
     hasBin: true
+    optionalDependencies:
+      chokidar: 2.1.8
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-O7mmzaWdm+VabWQmxuM8hqNrWGGihN83KfhPUzp2lAW4kzIMwBxujXkZbD4fMwKMYY9FXTbDvXsJqU+5XHXi4A==
+  /@babel/cli/7.7.4/@babel!core@7.7.4:
+    dependencies:
+      '@babel/core': 7.7.4
+      commander: 4.0.1
+      convert-source-map: 1.7.0
+      fs-readdir-recursive: 1.1.0
+      glob: 7.1.6
+      lodash: 4.17.15
+      make-dir: 2.1.0
+      slash: 2.0.0
+      source-map: 0.5.7
+    dev: false
+    hasBin: true
+    id: registry.npmjs.org/@babel/cli/7.7.4
     optionalDependencies:
       chokidar: 2.1.8
     peerDependencies:
@@ -733,6 +751,7 @@ packages:
       integrity: sha512-k8iVS7Jhc367IcNF53KCwIXtKAH7czev866ThsTgy8CwlXjnKZna2VHwChglzLleYrcHz1eQEIJlGRQxB53nqA==
   /@babel/plugin-transform-modules-commonjs/7.7.4/@babel!core@7.7.4:
     dependencies:
+      '@babel/core': 7.7.4
       '@babel/helper-module-transforms': 7.7.4
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-simple-access': 7.7.4
@@ -971,7 +990,7 @@ packages:
       '@babel/plugin-transform-typeof-symbol': /@babel/plugin-transform-typeof-symbol/7.7.4/@babel!core@7.7.4
       '@babel/plugin-transform-unicode-regex': /@babel/plugin-transform-unicode-regex/7.7.4/@babel!core@7.7.4
       '@babel/types': 7.7.4
-      browserslist: 4.7.3
+      browserslist: 4.8.0
       core-js-compat: 3.4.5
       invariant: 2.2.4
       js-levenshtein: 1.1.6
@@ -1106,35 +1125,12 @@ packages:
       typescript: '>= 3.3.0 || >= 3.6.0-dev || >= 3.7.0-dev'
     resolution:
       integrity: sha512-ou8VU+nTmOW1jeg+FT+sn+an/M0Xb9G16RucrfhjXGWv1Q97kCoM5CG9Qj7GYOSdu7km72k7nY83Eyr53Bkakg==
-  /@fimbul/bifrost/0.21.0/tslint@5.20.1+typescript@3.7.2:
-    dependencies:
-      '@fimbul/ymir': /@fimbul/ymir/0.21.0/tsutils@3.17.1+typescript@3.7.2
-      tslint: /tslint/5.20.1/typescript@3.7.2
-      tsutils: /tsutils/3.17.1/typescript@3.7.2
-      typescript: 3.7.2
-    dev: false
-    id: registry.npmjs.org/@fimbul/bifrost/0.21.0
-    peerDependencies:
-      tslint: ^5.0.0
-      typescript: '>= 3.3.0 || >= 3.6.0-dev || >= 3.7.0-dev'
-    resolution:
-      integrity: sha512-ou8VU+nTmOW1jeg+FT+sn+an/M0Xb9G16RucrfhjXGWv1Q97kCoM5CG9Qj7GYOSdu7km72k7nY83Eyr53Bkakg==
   /@fimbul/ymir/0.21.0/tsutils@3.17.1:
     dependencies:
       inversify: 5.0.1
       reflect-metadata: 0.1.13
       tslib: 1.10.0
-    dev: false
-    id: registry.npmjs.org/@fimbul/ymir/0.21.0
-    peerDependencies:
-      tsutils: '>=2.29.0'
-      typescript: '>= 3.3.0 || >= 3.6.0-dev || >= 3.7.0-dev'
-    resolution:
-      integrity: sha512-T/y7WqPsm4n3zhT08EpB5sfdm2Kvw3gurAxr2Lr5dQeLi8ZsMlNT/Jby+ZmuuAAd1PnXYzKp+2SXgIkQIIMCUg==
-  /@fimbul/ymir/0.21.0/tsutils@3.17.1+typescript@3.7.2:
-    dependencies:
-      tsutils: /tsutils/3.17.1/typescript@3.7.2
-      typescript: 3.7.2
+      tsutils: 3.17.1
     dev: false
     id: registry.npmjs.org/@fimbul/ymir/0.21.0
     peerDependencies:
@@ -1433,16 +1429,6 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-B1ZWbgzwxDhNZLzVnn+JjyFf9u+J9wNwsz/ZX9YvA9edRYcdiJz9JikCttGPi35V0NU0TUV4UqTqo/q/wQ06jQ==
-  /@oclif/tslint/3.1.1/tslint@5.20.1+typescript@3.7.2:
-    dependencies:
-      tslint-eslint-rules: /tslint-eslint-rules/5.4.0/tslint@5.20.1+typescript@3.7.2
-      tslint-xo: /tslint-xo/0.9.0/tslint@5.20.1+typescript@3.7.2
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    id: registry.npmjs.org/@oclif/tslint/3.1.1
-    resolution:
-      integrity: sha512-B1ZWbgzwxDhNZLzVnn+JjyFf9u+J9wNwsz/ZX9YvA9edRYcdiJz9JikCttGPi35V0NU0TUV4UqTqo/q/wQ06jQ==
   /@octokit/endpoint/5.5.1:
     dependencies:
       '@octokit/types': 2.0.2
@@ -1495,31 +1481,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-StASIL2lgT3TRjxv17z9pAqbnI7HGu9DrJlg3sEBFfCLaMEqp+O3IQPUF6EZtQ4xkAu2ml6kMBBCtGxjvmtmuQ==
-  /@reshuffle/interfaces-koa-server/0.5.1:
-    dependencies:
-      '@types/koa': 2.11.0
-      '@types/koa-bodyparser': 5.0.2
-      '@types/koa-router': 7.0.35
-      ajv: 6.10.2
-      koa: 2.11.0
-      koa-bodyparser: 4.2.1
-      koa-router: 7.4.0
-      lodash: 4.17.15
-    dev: false
-    peerDependencies:
-      '@types/node': '>=8.0.0'
-    resolution:
-      integrity: sha512-Ddg1wFa8jHBdYYcwlflppg3lqimxZx2IzCCK8T3KB+wJuP3i8RKX3h2gHy3szA842GYNkn9UQUq170RDbpCQlQ==
-  /@reshuffle/interfaces-node-client/0.5.1:
-    dependencies:
-      '@types/node-fetch': 2.5.4
-      abort-controller: 2.0.3
-      ajv: 6.10.2
-      lodash: 4.17.15
-      node-fetch: 2.6.0
-    dev: false
-    resolution:
-      integrity: sha512-vVUbz6PNgEGsY7K5bWMRjXyZG+S3t9d+DL35IVTbz+YFrujXefRynpvHa1HK/l1MvmdFOuyGA9Hcf2/y7yfh4A==
   /@sindresorhus/is/0.14.0:
     dev: false
     engines:
@@ -1911,7 +1872,7 @@ packages:
       integrity: sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
   /@types/ramda/0.26.36:
     dependencies:
-      ts-toolbelt: 4.10.21
+      ts-toolbelt: 4.12.5
     dev: false
     resolution:
       integrity: sha512-uo22Nf32Cc3EURp9tYlFttY8MVQZ1zoVum+D+yQ2jm4IqQFxDtwCQlP/WMwbuj4ey5kw1rJ7v6OacDszfWiqLA==
@@ -2008,11 +1969,11 @@ packages:
     dev: false
     resolution:
       integrity: sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==
-  /@typescript-eslint/eslint-plugin/2.9.0/4203db3fb47cd781f0c623114fbc2183:
+  /@typescript-eslint/eslint-plugin/2.9.0/23c0702e685a1d5aad1a73b60234aba6:
     dependencies:
-      '@typescript-eslint/experimental-utils': /@typescript-eslint/experimental-utils/2.9.0/eslint@6.7.1+typescript@3.7.2
-      '@typescript-eslint/parser': /@typescript-eslint/parser/2.9.0/eslint@6.7.1+typescript@3.7.2
-      eslint: 6.7.1
+      '@typescript-eslint/experimental-utils': /@typescript-eslint/experimental-utils/2.9.0/eslint@6.7.2+typescript@3.7.2
+      '@typescript-eslint/parser': /@typescript-eslint/parser/2.9.0/eslint@6.7.2+typescript@3.7.2
+      eslint: 6.7.2
       eslint-utils: 1.4.3
       functional-red-black-tree: 1.0.1
       regexpp: 3.0.0
@@ -2026,11 +1987,11 @@ packages:
       eslint: ^5.0.0 || ^6.0.0
     resolution:
       integrity: sha512-98rfOt3NYn5Gr9wekTB8TexxN6oM8ZRvYuphPs1Atfsy419SDLYCaE30aJkRiiTCwGEY98vOhFsEVm7Zs4toQQ==
-  /@typescript-eslint/experimental-utils/2.9.0/eslint@6.7.1+typescript@3.7.2:
+  /@typescript-eslint/experimental-utils/2.9.0/eslint@6.7.2+typescript@3.7.2:
     dependencies:
       '@types/json-schema': 7.0.3
       '@typescript-eslint/typescript-estree': /@typescript-eslint/typescript-estree/2.9.0/typescript@3.7.2
-      eslint: 6.7.1
+      eslint: 6.7.2
       eslint-scope: 5.0.0
     dev: false
     engines:
@@ -2040,12 +2001,12 @@ packages:
       eslint: '*'
     resolution:
       integrity: sha512-0lOLFdpdJsCMqMSZT7l7W2ta0+GX8A3iefG3FovJjrX+QR8y6htFlFdU7aOVPL6pDvt6XcsOb8fxk5sq+girTw==
-  /@typescript-eslint/parser/2.9.0/eslint@6.7.1+typescript@3.7.2:
+  /@typescript-eslint/parser/2.9.0/eslint@6.7.2+typescript@3.7.2:
     dependencies:
       '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': /@typescript-eslint/experimental-utils/2.9.0/eslint@6.7.1+typescript@3.7.2
+      '@typescript-eslint/experimental-utils': /@typescript-eslint/experimental-utils/2.9.0/eslint@6.7.2+typescript@3.7.2
       '@typescript-eslint/typescript-estree': /@typescript-eslint/typescript-estree/2.9.0/typescript@3.7.2
-      eslint: 6.7.1
+      eslint: 6.7.2
       eslint-visitor-keys: 1.1.0
     dev: false
     engines:
@@ -2505,7 +2466,7 @@ packages:
       array-union: 2.1.0
       array-uniq: 2.1.0
       arrify: 2.0.1
-      bluebird: 3.7.1
+      bluebird: 3.7.2
       chalk: 2.4.2
       chokidar: 3.3.0
       chunkd: 1.0.0
@@ -2595,13 +2556,13 @@ packages:
     dev: false
     resolution:
       integrity: sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=
-  /babel-eslint/10.0.3/eslint@6.7.1:
+  /babel-eslint/10.0.3/eslint@6.7.2:
     dependencies:
       '@babel/code-frame': 7.5.5
       '@babel/parser': 7.7.4
       '@babel/traverse': 7.7.4
       '@babel/types': 7.7.4
-      eslint: 6.7.1
+      eslint: 6.7.2
       eslint-visitor-keys: 1.1.0
       resolve: 1.13.1
     dev: false
@@ -2825,10 +2786,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==
-  /bluebird/3.7.1:
+  /bluebird/3.7.2:
     dev: false
     resolution:
-      integrity: sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==
+      integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
   /blueimp-md5/2.12.0:
     dev: false
     resolution:
@@ -2921,15 +2882,15 @@ packages:
     dev: false
     resolution:
       integrity: sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==
-  /browserslist/4.7.3:
+  /browserslist/4.8.0:
     dependencies:
       caniuse-lite: 1.0.30001012
-      electron-to-chromium: 1.3.314
+      electron-to-chromium: 1.3.319
       node-releases: 1.1.41
     dev: false
     hasBin: true
     resolution:
-      integrity: sha512-jWvmhqYpx+9EZm/FxcZSbUZyDEvDTLDi3nSAKbzEkyWvtI0mNSmUosey+5awDW1RUlrgXbQb5A6qY1xQH9U6MQ==
+      integrity: sha512-HYnxc/oLRWvJ3TsGegR0SRL/UDnknGq2s/a8dYYEO+kOQ9m9apKoS5oiathLKZdh/e9uE+/J3j92qPlGD/vTqA==
   /bs-logger/0.2.6:
     dependencies:
       fast-json-stable-stringify: 2.0.0
@@ -2976,7 +2937,7 @@ packages:
       integrity: sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
   /cacache/12.0.3:
     dependencies:
-      bluebird: 3.7.1
+      bluebird: 3.7.2
       chownr: 1.1.3
       figgy-pudding: 3.5.1
       glob: 7.1.6
@@ -3685,7 +3646,7 @@ packages:
       integrity: sha1-JoD7uAaKSNCGVrYJgJK9r8kG9KU=
   /core-js-compat/3.4.5:
     dependencies:
-      browserslist: 4.7.3
+      browserslist: 4.8.0
       semver: 6.3.0
     dev: false
     resolution:
@@ -4143,10 +4104,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-  /electron-to-chromium/1.3.314:
+  /electron-to-chromium/1.3.319:
     dev: false
     resolution:
-      integrity: sha512-IKDR/xCxKFhPts7h+VaSXS02Z1mznP3fli1BbXWXeN89i2gCzKraU8qLpEid8YzKcmZdZD3Mly3cn5/lY9xsBQ==
+      integrity: sha512-t/lYNZPwS9jLJ9SBLGd6ERYtCtsYPAXzsE1VYLshrUWpQCTAswO1pERZV4iOZipW2uVsGQrJtm2iWiYVp1zTZw==
   /emittery/0.4.1:
     dev: false
     engines:
@@ -4318,9 +4279,9 @@ packages:
       source-map: 0.6.1
     resolution:
       integrity: sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==
-  /eslint-config-prettier/6.7.0/eslint@6.7.1:
+  /eslint-config-prettier/6.7.0/eslint@6.7.2:
     dependencies:
-      eslint: 6.7.1
+      eslint: 6.7.2
       get-stdin: 6.0.0
     dev: false
     hasBin: true
@@ -4329,18 +4290,18 @@ packages:
       eslint: '>=3.14.1'
     resolution:
       integrity: sha512-FamQVKM3jjUVwhG4hEMnbtsq7xOIDm+SY5iBPfR8gKsJoAB2IQnNF+bk1+8Fy44Nq7PPJaLvkRxILYdJWoguKQ==
-  /eslint-config-react-app/5.0.2/437acfeca0c3c49554feff27153f72af:
+  /eslint-config-react-app/5.0.2/e9a2d216a8f027f6b67e1bd25992cf8b:
     dependencies:
-      '@typescript-eslint/eslint-plugin': /@typescript-eslint/eslint-plugin/2.9.0/4203db3fb47cd781f0c623114fbc2183
-      '@typescript-eslint/parser': /@typescript-eslint/parser/2.9.0/eslint@6.7.1+typescript@3.7.2
-      babel-eslint: /babel-eslint/10.0.3/eslint@6.7.1
+      '@typescript-eslint/eslint-plugin': /@typescript-eslint/eslint-plugin/2.9.0/23c0702e685a1d5aad1a73b60234aba6
+      '@typescript-eslint/parser': /@typescript-eslint/parser/2.9.0/eslint@6.7.2+typescript@3.7.2
+      babel-eslint: /babel-eslint/10.0.3/eslint@6.7.2
       confusing-browser-globals: 1.0.9
-      eslint: 6.7.1
-      eslint-plugin-flowtype: /eslint-plugin-flowtype/3.13.0/eslint@6.7.1
-      eslint-plugin-import: /eslint-plugin-import/2.18.2/eslint@6.7.1
-      eslint-plugin-jsx-a11y: /eslint-plugin-jsx-a11y/6.2.3/eslint@6.7.1
-      eslint-plugin-react: /eslint-plugin-react/7.16.0/eslint@6.7.1
-      eslint-plugin-react-hooks: /eslint-plugin-react-hooks/1.7.0/eslint@6.7.1
+      eslint: 6.7.2
+      eslint-plugin-flowtype: /eslint-plugin-flowtype/3.13.0/eslint@6.7.2
+      eslint-plugin-import: /eslint-plugin-import/2.18.2/eslint@6.7.2
+      eslint-plugin-jsx-a11y: /eslint-plugin-jsx-a11y/6.2.3/eslint@6.7.2
+      eslint-plugin-react: /eslint-plugin-react/7.17.0/eslint@6.7.2
+      eslint-plugin-react-hooks: /eslint-plugin-react-hooks/1.7.0/eslint@6.7.2
     dev: false
     id: registry.npmjs.org/eslint-config-react-app/5.0.2
     peerDependencies:
@@ -4371,9 +4332,20 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==
-  /eslint-plugin-flowtype/3.13.0/eslint@6.7.1:
+  /eslint-plugin-eslint-plugin/2.1.0/eslint@6.7.2:
     dependencies:
-      eslint: 6.7.1
+      eslint: 6.7.2
+    dev: false
+    engines:
+      node: ^6.14.0 || ^8.10.0 || >=9.10.0
+    id: registry.npmjs.org/eslint-plugin-eslint-plugin/2.1.0
+    peerDependencies:
+      eslint: '>=5.0.0'
+    resolution:
+      integrity: sha512-kT3A/ZJftt28gbl/Cv04qezb/NQ1dwYIbi8lyf806XMxkus7DvOVCLIfTXMrorp322Pnoez7+zabXH29tADIDg==
+  /eslint-plugin-flowtype/3.13.0/eslint@6.7.2:
+    dependencies:
+      eslint: 6.7.2
       lodash: 4.17.15
     dev: false
     engines:
@@ -4383,13 +4355,13 @@ packages:
       eslint: '>=5.0.0'
     resolution:
       integrity: sha512-bhewp36P+t7cEV0b6OdmoRWJCBYRiHFlqPZAG1oS3SF+Y0LQkeDvFSM4oxoxvczD1OdONCXMlJfQFiWLcV9urw==
-  /eslint-plugin-import/2.18.2/eslint@6.7.1:
+  /eslint-plugin-import/2.18.2/eslint@6.7.2:
     dependencies:
       array-includes: 3.0.3
       contains-path: 0.1.0
       debug: 2.6.9
       doctrine: 1.5.0
-      eslint: 6.7.1
+      eslint: 6.7.2
       eslint-import-resolver-node: 0.3.2
       eslint-module-utils: 2.4.1
       has: 1.0.3
@@ -4405,7 +4377,7 @@ packages:
       eslint: 2.x - 6.x
     resolution:
       integrity: sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==
-  /eslint-plugin-jsx-a11y/6.2.3/eslint@6.7.1:
+  /eslint-plugin-jsx-a11y/6.2.3/eslint@6.7.2:
     dependencies:
       '@babel/runtime': 7.7.4
       aria-query: 3.0.0
@@ -4414,7 +4386,7 @@ packages:
       axobject-query: 2.0.2
       damerau-levenshtein: 1.0.5
       emoji-regex: 7.0.3
-      eslint: 6.7.1
+      eslint: 6.7.2
       has: 1.0.3
       jsx-ast-utils: 2.2.3
     dev: false
@@ -4425,9 +4397,9 @@ packages:
       eslint: ^3 || ^4 || ^5 || ^6
     resolution:
       integrity: sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==
-  /eslint-plugin-prettier/3.1.1/eslint@6.7.1+prettier@1.19.1:
+  /eslint-plugin-prettier/3.1.1/eslint@6.7.2+prettier@1.19.1:
     dependencies:
-      eslint: 6.7.1
+      eslint: 6.7.2
       prettier: 1.19.1
       prettier-linter-helpers: 1.0.0
     dev: false
@@ -4439,9 +4411,9 @@ packages:
       prettier: '>= 1.13.0'
     resolution:
       integrity: sha512-A+TZuHZ0KU0cnn56/9mfR7/KjUJ9QNVXUhwvRFSR7PGPe0zQR6PTkmyqg1AtUUEOzTqeRsUwyKFh0oVZKVCrtA==
-  /eslint-plugin-react-hooks/1.7.0/eslint@6.7.1:
+  /eslint-plugin-react-hooks/1.7.0/eslint@6.7.2:
     dependencies:
-      eslint: 6.7.1
+      eslint: 6.7.2
     dev: false
     engines:
       node: '>=7'
@@ -4450,11 +4422,12 @@ packages:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
     resolution:
       integrity: sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==
-  /eslint-plugin-react/7.16.0/eslint@6.7.1:
+  /eslint-plugin-react/7.17.0/eslint@6.7.2:
     dependencies:
       array-includes: 3.0.3
       doctrine: 2.1.0
-      eslint: 6.7.1
+      eslint: 6.7.2
+      eslint-plugin-eslint-plugin: /eslint-plugin-eslint-plugin/2.1.0/eslint@6.7.2
       has: 1.0.3
       jsx-ast-utils: 2.2.3
       object.entries: 1.1.0
@@ -4465,11 +4438,11 @@ packages:
     dev: false
     engines:
       node: '>=4'
-    id: registry.npmjs.org/eslint-plugin-react/7.16.0
+    id: registry.npmjs.org/eslint-plugin-react/7.17.0
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
     resolution:
-      integrity: sha512-GacBAATewhhptbK3/vTP09CbFrgUJmBSaaRcWdbQLFvUZy9yVcQxigBNHGPU/KE2AyHpzj3AWXpxoMTsIDiHug==
+      integrity: sha512-ODB7yg6lxhBVMeiH1c7E95FLD4E/TwmFjltiU+ethv7KPdCwgiFuOZg9zNRHyufStTDLl/dEFqI2Q1VPmCd78A==
   /eslint-scope/5.0.0:
     dependencies:
       esrecurse: 4.2.1
@@ -4493,7 +4466,7 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
-  /eslint/6.7.1:
+  /eslint/6.7.2:
     dependencies:
       '@babel/code-frame': 7.5.5
       ajv: 6.10.2
@@ -4537,7 +4510,7 @@ packages:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     hasBin: true
     resolution:
-      integrity: sha512-UWzBS79pNcsDSxgxbdjkmzn/B6BhsXMfUaOHnNwyE8nD+Q6pyT96ow2MccVayUTV4yMid4qLhMiQaywctRkBLA==
+      integrity: sha512-qMlSWJaCSxDFr8fBPvJM9kJwbazrhNcBU3+DszDW1OlEwKBBRWsJc7NJFelvwQpanHCR14cOLD41x8Eqvo3Nng==
   /esm/3.2.25:
     dev: false
     engines:
@@ -5375,7 +5348,7 @@ packages:
       node: '>=0.4.7'
     hasBin: true
     optionalDependencies:
-      uglify-js: 3.7.0
+      uglify-js: 3.7.1
     resolution:
       integrity: sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
   /har-schema/2.0.0:
@@ -7936,7 +7909,7 @@ packages:
   /npm-registry-fetch/4.0.2:
     dependencies:
       JSONStream: 1.3.5
-      bluebird: 3.7.1
+      bluebird: 3.7.2
       figgy-pudding: 3.5.1
       lru-cache: 5.1.1
       make-fetch-happen: 5.0.2
@@ -8454,7 +8427,7 @@ packages:
       integrity: sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==
   /pacote/9.5.9:
     dependencies:
-      bluebird: 3.7.1
+      bluebird: 3.7.2
       cacache: 12.0.3
       chownr: 1.1.3
       figgy-pudding: 3.5.1
@@ -8958,10 +8931,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
-  /psl/1.4.0:
+  /psl/1.5.0:
     dev: false
     resolution:
-      integrity: sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==
+      integrity: sha512-4vqUjKi2huMu1OJiLhi3jN6jeeKvMZdI1tYgi/njW5zV52jNLgSAZSdN16m9bJFe61/cT8ulmw4qFitV9QRsEA==
   /pstree.remy/1.1.7:
     dev: false
     resolution:
@@ -9111,6 +9084,18 @@ packages:
     engines:
       node: '>=8'
       npm: '>=5'
+    peerDependencies:
+      react: '>=16.8'
+    resolution:
+      integrity: sha512-YWBB2feVQF79t5u2raMPHlZ8975Jds+guCvkWVC4kRLDlSCouLsYpQm4DGSqPeHvoHYVVcDfqNayLZAXQmnxnw==
+  /react-async-hook/3.6.1/react@16.12.0:
+    dependencies:
+      react: 16.12.0
+    dev: false
+    engines:
+      node: '>=8'
+      npm: '>=5'
+    id: registry.npmjs.org/react-async-hook/3.6.1
     peerDependencies:
       react: '>=16.8'
     resolution:
@@ -9607,11 +9592,11 @@ packages:
     dev: false
     resolution:
       integrity: sha512-nQptLCZeyyJfgbpf2x97k5YE8vzDn7bhwx9NlvODdhgbU0mL1ruh71X0HYdRaOEvWC7Cr+SfV0p5p+Ib5yOl7A==
-  /rollup-plugin-babel/4.3.3/@babel!core@7.7.4+rollup@1.27.5:
+  /rollup-plugin-babel/4.3.3/@babel!core@7.7.4+rollup@1.27.6:
     dependencies:
       '@babel/core': 7.7.4
       '@babel/helper-module-imports': 7.7.4
-      rollup: 1.27.5
+      rollup: 1.27.6
       rollup-pluginutils: 2.8.2
     dev: false
     id: registry.npmjs.org/rollup-plugin-babel/4.3.3
@@ -9620,13 +9605,13 @@ packages:
       rollup: '>=0.60.0 <2'
     resolution:
       integrity: sha512-tKzWOCmIJD/6aKNz0H1GMM+lW1q9KyFubbWzGiOG540zxPPifnEAHTZwjo0g991Y+DyOZcLqBgqOdqazYE5fkw==
-  /rollup-plugin-commonjs/10.1.0/rollup@1.27.5:
+  /rollup-plugin-commonjs/10.1.0/rollup@1.27.6:
     dependencies:
       estree-walker: 0.6.1
       is-reference: 1.1.4
       magic-string: 0.25.4
       resolve: 1.13.1
-      rollup: 1.27.5
+      rollup: 1.27.6
       rollup-pluginutils: 2.8.2
     dev: false
     id: registry.npmjs.org/rollup-plugin-commonjs/10.1.0
@@ -9641,13 +9626,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-hgb8N7Cgfw5SZAkb3jf0QXii6QX/FOkiIq2M7BAQIEydjHvTyxXHQiIzZaTFgx1GK0cRCHOCBHIyEkkLdWKxow==
-  /rollup-plugin-node-resolve/5.2.0/rollup@1.27.5:
+  /rollup-plugin-node-resolve/5.2.0/rollup@1.27.6:
     dependencies:
       '@types/resolve': 0.0.8
       builtin-modules: 3.1.0
       is-module: 1.0.0
       resolve: 1.13.1
-      rollup: 1.27.5
+      rollup: 1.27.6
       rollup-pluginutils: 2.8.2
     dev: false
     id: registry.npmjs.org/rollup-plugin-node-resolve/5.2.0
@@ -9663,9 +9648,9 @@ packages:
     dev: false
     resolution:
       integrity: sha512-/5bxtUPkDHyBJAKketb4NfaeZjL5yLZdeUihSfbF2PQMz+rSTEb8ARKoOl3UBT4m7/X+QOXJo3sLTcq+yMMYTA==
-  /rollup-plugin-sourcemaps/0.4.2/rollup@1.27.5:
+  /rollup-plugin-sourcemaps/0.4.2/rollup@1.27.6:
     dependencies:
-      rollup: 1.27.5
+      rollup: 1.27.6
       rollup-pluginutils: 2.8.2
       source-map-resolve: 0.5.2
     dev: false
@@ -9677,11 +9662,11 @@ packages:
       rollup: '>=0.31.2'
     resolution:
       integrity: sha1-YhJaqUCHqt97g+9N+vYptHMTXoc=
-  /rollup-plugin-terser/5.1.2/rollup@1.27.5:
+  /rollup-plugin-terser/5.1.2/rollup@1.27.6:
     dependencies:
       '@babel/code-frame': 7.5.5
       jest-worker: 24.9.0
-      rollup: 1.27.5
+      rollup: 1.27.6
       rollup-pluginutils: 2.8.2
       serialize-javascript: 1.9.1
       terser: 4.4.0
@@ -9691,12 +9676,12 @@ packages:
       rollup: '>=0.66.0 <2'
     resolution:
       integrity: sha512-sWKBCOS+vUkRtHtEiJPAf+WnBqk/C402fBD9AVHxSIXMqjsY7MnYWKYEUqGixtr0c8+1DjzUEPlNgOYQPVrS1g==
-  /rollup-plugin-typescript2/0.24.3/rollup@1.27.5+typescript@3.7.2:
+  /rollup-plugin-typescript2/0.24.3/rollup@1.27.6+typescript@3.7.2:
     dependencies:
       find-cache-dir: 3.1.0
       fs-extra: 8.1.0
       resolve: 1.12.0
-      rollup: 1.27.5
+      rollup: 1.27.6
       rollup-pluginutils: 2.8.1
       tslib: 1.10.0
       typescript: 3.7.2
@@ -9719,7 +9704,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
-  /rollup/1.27.5:
+  /rollup/1.27.6:
     dependencies:
       '@types/estree': 0.0.40
       '@types/node': 12.12.14
@@ -9727,7 +9712,7 @@ packages:
     dev: false
     hasBin: true
     resolution:
-      integrity: sha512-8rfVdzuTg2kt8ObD9LNJpEwUN7B6lsl3sHc5fddtgICpLjpYeSf4m2+RftBzcCaBTMi1iYX3Ez8zFT4Gj2nJjg==
+      integrity: sha512-/NA1sjU92K9KZHiPdrHMzykFABcjeDaxS8xh19hYj8FKbtGNEahbXkdYatlk75dZF0oRXwzA9KIjHedcxcnYng==
   /rsvp/4.8.5:
     dev: false
     engines:
@@ -10730,7 +10715,7 @@ packages:
       integrity: sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==
   /tough-cookie/2.4.3:
     dependencies:
-      psl: 1.4.0
+      psl: 1.5.0
       punycode: 1.4.1
     dev: false
     engines:
@@ -10739,7 +10724,7 @@ packages:
       integrity: sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==
   /tough-cookie/2.5.0:
     dependencies:
-      psl: 1.4.0
+      psl: 1.5.0
       punycode: 2.1.1
     dev: false
     engines:
@@ -10802,7 +10787,7 @@ packages:
       jest: '>=24 <25'
     resolution:
       integrity: sha512-Yc+HLyldlIC9iIK8xEN7tV960Or56N49MDP7hubCZUeI7EbIOTsas6rXCMB4kQjLACJ7eDOF4xWEO5qumpKsag==
-  /ts-node/8.5.3:
+  /ts-node/8.5.4:
     dependencies:
       arg: 4.1.2
       diff: 4.0.1
@@ -10816,8 +10801,8 @@ packages:
     peerDependencies:
       typescript: '>=2.0'
     resolution:
-      integrity: sha512-B4dYs62o9ioIilzh7Npby5grYvw3lLwttTSIzf7QObf1FWUCzt+ELtyZJd+xYgxJ/n3A5nQJ2oG6VaZgwMMcjA==
-  /ts-node/8.5.3/typescript@3.7.2:
+      integrity: sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==
+  /ts-node/8.5.4/typescript@3.7.2:
     dependencies:
       arg: 4.1.2
       diff: 4.0.1
@@ -10829,15 +10814,15 @@ packages:
     engines:
       node: '>=4.2.0'
     hasBin: true
-    id: registry.npmjs.org/ts-node/8.5.3
+    id: registry.npmjs.org/ts-node/8.5.4
     peerDependencies:
       typescript: '>=2.0'
     resolution:
-      integrity: sha512-B4dYs62o9ioIilzh7Npby5grYvw3lLwttTSIzf7QObf1FWUCzt+ELtyZJd+xYgxJ/n3A5nQJ2oG6VaZgwMMcjA==
-  /ts-toolbelt/4.10.21:
+      integrity: sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==
+  /ts-toolbelt/4.12.5:
     dev: false
     resolution:
-      integrity: sha512-89MjhFYWESgNoQVFZXmZL8o25cOg/7nlky2XyDEyXFMFj8SvjGPnvm1mcZSkKO+ipBHa5iforjAJ4ZScaBokUA==
+      integrity: sha512-LxyONMKpDNPYtO3s63lQ7YNw93Xpsf6Krrvx/5XHT2I9YqgSZ0C+fERQKVklRgXOK+QhdDYplRvgdWPt43Eo0A==
   /tsdx/0.11.0:
     dependencies:
       '@babel/core': 7.7.4
@@ -10850,11 +10835,11 @@ packages:
       '@babel/preset-env': /@babel/preset-env/7.7.4/@babel!core@7.7.4
       '@types/rimraf': 2.0.3
       '@types/shelljs': 0.8.6
-      '@typescript-eslint/eslint-plugin': /@typescript-eslint/eslint-plugin/2.9.0/4203db3fb47cd781f0c623114fbc2183
-      '@typescript-eslint/parser': /@typescript-eslint/parser/2.9.0/eslint@6.7.1+typescript@3.7.2
+      '@typescript-eslint/eslint-plugin': /@typescript-eslint/eslint-plugin/2.9.0/23c0702e685a1d5aad1a73b60234aba6
+      '@typescript-eslint/parser': /@typescript-eslint/parser/2.9.0/eslint@6.7.2+typescript@3.7.2
       ansi-escapes: 4.3.0
       asyncro: 3.0.0
-      babel-eslint: /babel-eslint/10.0.3/eslint@6.7.1
+      babel-eslint: /babel-eslint/10.0.3/eslint@6.7.2
       babel-plugin-annotate-pure-calls: /babel-plugin-annotate-pure-calls/0.4.0/@babel!core@7.7.4
       babel-plugin-dev-expression: /babel-plugin-dev-expression/0.2.2/@babel!core@7.7.4
       babel-plugin-macros: 2.7.1
@@ -10866,15 +10851,15 @@ packages:
       chalk: 2.4.2
       cross-env: 6.0.3
       enquirer: 2.3.2
-      eslint: 6.7.1
-      eslint-config-prettier: /eslint-config-prettier/6.7.0/eslint@6.7.1
-      eslint-config-react-app: /eslint-config-react-app/5.0.2/437acfeca0c3c49554feff27153f72af
-      eslint-plugin-flowtype: /eslint-plugin-flowtype/3.13.0/eslint@6.7.1
-      eslint-plugin-import: /eslint-plugin-import/2.18.2/eslint@6.7.1
-      eslint-plugin-jsx-a11y: /eslint-plugin-jsx-a11y/6.2.3/eslint@6.7.1
-      eslint-plugin-prettier: /eslint-plugin-prettier/3.1.1/eslint@6.7.1+prettier@1.19.1
-      eslint-plugin-react: /eslint-plugin-react/7.16.0/eslint@6.7.1
-      eslint-plugin-react-hooks: /eslint-plugin-react-hooks/1.7.0/eslint@6.7.1
+      eslint: 6.7.2
+      eslint-config-prettier: /eslint-config-prettier/6.7.0/eslint@6.7.2
+      eslint-config-react-app: /eslint-config-react-app/5.0.2/e9a2d216a8f027f6b67e1bd25992cf8b
+      eslint-plugin-flowtype: /eslint-plugin-flowtype/3.13.0/eslint@6.7.2
+      eslint-plugin-import: /eslint-plugin-import/2.18.2/eslint@6.7.2
+      eslint-plugin-jsx-a11y: /eslint-plugin-jsx-a11y/6.2.3/eslint@6.7.2
+      eslint-plugin-prettier: /eslint-plugin-prettier/3.1.1/eslint@6.7.2+prettier@1.19.1
+      eslint-plugin-react: /eslint-plugin-react/7.17.0/eslint@6.7.2
+      eslint-plugin-react-hooks: /eslint-plugin-react-hooks/1.7.0/eslint@6.7.2
       execa: 3.1.0
       fs-extra: 8.1.0
       jest: 24.9.0
@@ -10887,15 +10872,15 @@ packages:
       prettier: 1.19.1
       progress-estimator: 0.2.2
       rimraf: 3.0.0
-      rollup: 1.27.5
-      rollup-plugin-babel: /rollup-plugin-babel/4.3.3/@babel!core@7.7.4+rollup@1.27.5
-      rollup-plugin-commonjs: /rollup-plugin-commonjs/10.1.0/rollup@1.27.5
+      rollup: 1.27.6
+      rollup-plugin-babel: /rollup-plugin-babel/4.3.3/@babel!core@7.7.4+rollup@1.27.6
+      rollup-plugin-commonjs: /rollup-plugin-commonjs/10.1.0/rollup@1.27.6
       rollup-plugin-json: 4.0.0
-      rollup-plugin-node-resolve: /rollup-plugin-node-resolve/5.2.0/rollup@1.27.5
+      rollup-plugin-node-resolve: /rollup-plugin-node-resolve/5.2.0/rollup@1.27.6
       rollup-plugin-replace: 2.2.0
-      rollup-plugin-sourcemaps: /rollup-plugin-sourcemaps/0.4.2/rollup@1.27.5
-      rollup-plugin-terser: /rollup-plugin-terser/5.1.2/rollup@1.27.5
-      rollup-plugin-typescript2: /rollup-plugin-typescript2/0.24.3/rollup@1.27.5+typescript@3.7.2
+      rollup-plugin-sourcemaps: /rollup-plugin-sourcemaps/0.4.2/rollup@1.27.6
+      rollup-plugin-terser: /rollup-plugin-terser/5.1.2/rollup@1.27.6
+      rollup-plugin-typescript2: /rollup-plugin-typescript2/0.24.3/rollup@1.27.6+typescript@3.7.2
       sade: 1.6.1
       shelljs: 0.8.3
       tiny-glob: 0.2.6
@@ -10925,37 +10910,12 @@ packages:
       typescript: '>=2.1.4 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >=3.1.0-dev || >=3.2.0-dev || >=3.3.0-dev || >=3.4.0-dev'
     resolution:
       integrity: sha512-ebR/xHyMEuU36hGNOgCfjGBNYxBPixf0yU1Yoo6s3BrpBRFccjPOmIVaVvQsWAUAMdmfzHOCihVkcaMfimqvHw==
-  /tslint-consistent-codestyle/1.16.0/tslint@5.20.1+typescript@3.7.2:
-    dependencies:
-      '@fimbul/bifrost': /@fimbul/bifrost/0.21.0/tslint@5.20.1+typescript@3.7.2
-      tslint: /tslint/5.20.1/typescript@3.7.2
-      tsutils: /tsutils/2.29.0/typescript@3.7.2
-      typescript: 3.7.2
-    dev: false
-    id: registry.npmjs.org/tslint-consistent-codestyle/1.16.0
-    peerDependencies:
-      tslint: ^5.0.0
-      typescript: '>=2.1.4 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >=3.1.0-dev || >=3.2.0-dev || >=3.3.0-dev || >=3.4.0-dev'
-    resolution:
-      integrity: sha512-ebR/xHyMEuU36hGNOgCfjGBNYxBPixf0yU1Yoo6s3BrpBRFccjPOmIVaVvQsWAUAMdmfzHOCihVkcaMfimqvHw==
   /tslint-eslint-rules/5.4.0:
     dependencies:
       doctrine: 0.7.2
       tslib: 1.9.0
       tsutils: 3.17.1
     dev: false
-    peerDependencies:
-      tslint: ^5.0.0
-      typescript: ^2.2.0 || ^3.0.0
-    resolution:
-      integrity: sha512-WlSXE+J2vY/VPgIcqQuijMQiel+UtmXS+4nvK4ZzlDiqBfXse8FAvkNnTcYhnQyOTW5KFM+uRRGXxYhFpuBc6w==
-  /tslint-eslint-rules/5.4.0/tslint@5.20.1+typescript@3.7.2:
-    dependencies:
-      tslint: /tslint/5.20.1/typescript@3.7.2
-      tsutils: /tsutils/3.17.1/typescript@3.7.2
-      typescript: 3.7.2
-    dev: false
-    id: registry.npmjs.org/tslint-eslint-rules/5.4.0
     peerDependencies:
       tslint: ^5.0.0
       typescript: ^2.2.0 || ^3.0.0
@@ -10970,18 +10930,6 @@ packages:
       typescript: ^2.1.0 || ^3.0.0
     resolution:
       integrity: sha512-PDYjvpo0gN9IfMULwKk0KpVOPMhU6cNoT9VwCOLeDl/QS8v8W2yspRpFFuUS7/c5EIH/n8ApMi8TxJAz1tfFUA==
-  /tslint-microsoft-contrib/5.2.1/tslint@5.20.1+typescript@3.7.2:
-    dependencies:
-      tslint: /tslint/5.20.1/typescript@3.7.2
-      tsutils: /tsutils/2.28.0/typescript@3.7.2
-      typescript: 3.7.2
-    dev: false
-    id: registry.npmjs.org/tslint-microsoft-contrib/5.2.1
-    peerDependencies:
-      tslint: ^5.1.0
-      typescript: ^2.1.0 || ^3.0.0
-    resolution:
-      integrity: sha512-PDYjvpo0gN9IfMULwKk0KpVOPMhU6cNoT9VwCOLeDl/QS8v8W2yspRpFFuUS7/c5EIH/n8ApMi8TxJAz1tfFUA==
   /tslint-xo/0.9.0:
     dependencies:
       tslint-consistent-codestyle: 1.16.0
@@ -10990,20 +10938,6 @@ packages:
     dev: false
     engines:
       node: '>=6'
-    peerDependencies:
-      tslint: '>=5.11.0'
-    resolution:
-      integrity: sha512-Zk5jBdQVUaHEmR9TUoh1TJOjjCr7/nRplA+jDZBvucyBMx65pt0unTr6H/0HvrtSlucFvOMYsyBZE1W8b4AOig==
-  /tslint-xo/0.9.0/tslint@5.20.1+typescript@3.7.2:
-    dependencies:
-      tslint: /tslint/5.20.1/typescript@3.7.2
-      tslint-consistent-codestyle: /tslint-consistent-codestyle/1.16.0/tslint@5.20.1+typescript@3.7.2
-      tslint-eslint-rules: /tslint-eslint-rules/5.4.0/tslint@5.20.1+typescript@3.7.2
-      tslint-microsoft-contrib: /tslint-microsoft-contrib/5.2.1/tslint@5.20.1+typescript@3.7.2
-    dev: false
-    engines:
-      node: '>=6'
-    id: registry.npmjs.org/tslint-xo/0.9.0
     peerDependencies:
       tslint: '>=5.11.0'
     resolution:
@@ -11066,15 +11000,6 @@ packages:
     dependencies:
       tslib: 1.10.0
     dev: false
-    peerDependencies:
-      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
-    resolution:
-      integrity: sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==
-  /tsutils/2.28.0/typescript@3.7.2:
-    dependencies:
-      typescript: 3.7.2
-    dev: false
-    id: registry.npmjs.org/tsutils/2.28.0
     peerDependencies:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
     resolution:
@@ -11238,7 +11163,7 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
-  /uglify-js/3.7.0:
+  /uglify-js/3.7.1:
     dependencies:
       commander: 2.20.3
       source-map: 0.6.1
@@ -11248,7 +11173,7 @@ packages:
     hasBin: true
     optional: true
     resolution:
-      integrity: sha512-PC/ee458NEMITe1OufAjal65i6lB58R1HWMRcxwvdz1UopW0DYqlRL3xdu3IcTvTXsB02CRHykidkTRL+A3hQA==
+      integrity: sha512-pnOF7jY82wdIhATVn87uUY/FHU+MDUdPLkmGFvGoclQmeu229eTkbG5gjGGBi3R7UuYYSEeYXY/TTY5j2aym2g==
   /uid2/0.0.3:
     dev: false
     resolution:
@@ -11861,7 +11786,7 @@ packages:
       mz: 2.7.0
       sleep-promise: 8.0.1
       tail: 2.0.3
-      tslint: 5.20.1
+      tslint: /tslint/5.20.1/typescript@3.7.2
       typescript: 3.7.2
     dev: false
     name: '@rush-temp/app-testsuite'
@@ -11889,7 +11814,7 @@ packages:
       babel-plugin-tester: 7.0.4
       jest: 24.9.0
       jest-standard-reporter: 1.0.2
-      tslint: 5.20.1
+      tslint: /tslint/5.20.1/typescript@3.7.2
       typescript: 3.7.2
     dev: false
     name: '@rush-temp/code-transform'
@@ -11899,7 +11824,6 @@ packages:
     version: 0.0.0
   'file:projects/db-testsuite.tgz':
     dependencies:
-      '@reshuffle/interfaces-koa-server': 0.5.1
       '@types/koa': 2.0.52
       '@types/koa-router': 7.0.42
       '@types/nanoid': 2.1.0
@@ -11910,17 +11834,16 @@ packages:
       koa-router: 7.4.0
       nanoid: 2.1.7
       ramda: 0.26.1
-      tslint: 5.20.1
+      tslint: /tslint/5.20.1/typescript@3.7.2
       typescript: 3.7.2
     dev: false
     name: '@rush-temp/db-testsuite'
     resolution:
-      integrity: sha512-lycWqO5FxAsS7UNSe+mOpkrPZPcixh48GtFaO3IaZmzpxipP1249hfwyFyShPL9rmJo19BDRNCOqTGO0bolNyQ==
+      integrity: sha512-ksjewn+4kl55Hy5Rbd8ixACZHMDJfm1s4pkrDo0nWKgBFlIA07dDUvc6R3/PJM7Irz38Il82/Unm5E8un4W3pw==
       tarball: 'file:projects/db-testsuite.tgz'
     version: 0.0.0
   'file:projects/db.tgz':
     dependencies:
-      '@reshuffle/interfaces-node-client': 0.5.1
       '@types/deep-freeze': 0.1.2
       '@types/node': 12.12.14
       '@types/ramda': 0.26.36
@@ -11932,13 +11855,13 @@ packages:
     dev: false
     name: '@rush-temp/db'
     resolution:
-      integrity: sha512-4TkMM7ddX0slcZE1FZpIoVBh1dWw4zWis0UeaV42UtaJ2oOjw5+cf1Yd3hW0Sclc7z8207ZCDuBb9pcYfEpukg==
+      integrity: sha512-LnQHL0l/ypvPJIJ/zFt7TQOEqDZiW0I0mlTgGSfeRHtu0lMdHSplKOQKMHsXvp8tq+fbb29aK3xip8Og4cWPgA==
       tarball: 'file:projects/db.tgz'
     version: 0.0.0
   'file:projects/fetch-runtime.tgz':
     dependencies:
       '@types/node': 10.17.6
-      tslint: 5.20.1
+      tslint: /tslint/5.20.1/typescript@3.7.2
       typescript: 3.7.2
     dev: false
     name: '@rush-temp/fetch-runtime'
@@ -11984,7 +11907,7 @@ packages:
       '@types/node': 10.17.6
       concord: 0.2.4
       fast-json-patch: 2.2.1
-      tslint: 5.20.1
+      tslint: /tslint/5.20.1/typescript@3.7.2
       typescript: 3.7.2
       typescript-json-schema: 0.40.0
     dev: false
@@ -11995,7 +11918,6 @@ packages:
     version: 0.0.0
   'file:projects/leveldb-server.tgz':
     dependencies:
-      '@reshuffle/interfaces-koa-server': 0.5.1
       '@types/deep-freeze': 0.1.2
       '@types/koa': 2.11.0
       '@types/leveldown': 4.0.2
@@ -12014,20 +11936,19 @@ packages:
       nanoid: 2.1.7
       ramda: 0.26.1
       rmfr: 2.0.0
-      tslint: 5.20.1
+      tslint: /tslint/5.20.1/typescript@3.7.2
       typescript: 3.7.2
     dev: false
     name: '@rush-temp/leveldb-server'
     resolution:
-      integrity: sha512-CwJ1oxIQ0nlFqbKwJwqbrMuqG8JtyMJ4M9E+MPezER2fYyBZEK4jhsIyvnUmrcZh/ey6taJJdmijCclP3QGNGA==
+      integrity: sha512-KF6WjiDZMfASZVetZf5FJLJkgafWShGVyY3D+N9E+ycHBqF/WV62tJSNSAMqnvfRXmCZxEe9KEg8VK3ZE5By1w==
       tarball: 'file:projects/leveldb-server.tgz'
     version: 0.0.0
   'file:projects/local-proxy.tgz':
     dependencies:
-      '@babel/cli': 7.7.4
+      '@babel/cli': /@babel/cli/7.7.4/@babel!core@7.7.4
       '@babel/core': 7.7.4
-      '@babel/plugin-transform-modules-commonjs': 7.7.4
-      '@reshuffle/interfaces-koa-server': 0.5.1
+      '@babel/plugin-transform-modules-commonjs': /@babel/plugin-transform-modules-commonjs/7.7.4/@babel!core@7.7.4
       '@types/babel__core': 7.1.3
       '@types/express': 4.17.2
       '@types/fs-extra': 8.0.1
@@ -12059,14 +11980,14 @@ packages:
       nanoid: 2.1.7
       nodemon: 1.19.4
       rimraf: 3.0.0
-      tslint: 5.20.1
+      tslint: /tslint/5.20.1/typescript@3.7.2
       typescript: 3.7.2
       walkdir: 0.4.1
       winston: 3.2.1
     dev: false
     name: '@rush-temp/local-proxy'
     resolution:
-      integrity: sha512-F0XJBe63a8HkSmlCeml/e+MMtRDIZxqnGUYsrNkoMQfynTTV5HXzvGygRYtZxcsdYnEgslsHAlNrFuUbWJdQbw==
+      integrity: sha512-2ALd2c84OgzrRb7+IetL9zpBEB66Z9PxIxTc3NQs68MsDuo35simaAXJpiIcP4AR1VZeRo04mOpAaJAbKKx7mQ==
       tarball: 'file:projects/local-proxy.tgz'
     version: 0.0.0
   'file:projects/passport.tgz':
@@ -12103,7 +12024,7 @@ packages:
       fixture-stdout: 0.2.1
       jest: 24.9.0
       rmfr: 2.0.0
-      tslint: 5.20.1
+      tslint: /tslint/5.20.1/typescript@3.7.2
       typescript: 3.7.2
     dev: false
     name: '@rush-temp/react-app'
@@ -12115,7 +12036,7 @@ packages:
     dependencies:
       '@types/react': 16.9.13
       react: 16.12.0
-      react-async-hook: 3.6.1
+      react-async-hook: /react-async-hook/3.6.1/react@16.12.0
       tsdx: 0.11.0
       typescript: 3.7.2
     dev: false
@@ -12136,7 +12057,7 @@ packages:
       '@oclif/errors': 1.2.2
       '@oclif/parser': 3.8.4
       '@oclif/plugin-help': 2.2.1
-      '@oclif/tslint': /@oclif/tslint/3.1.1/tslint@5.20.1+typescript@3.7.2
+      '@oclif/tslint': 3.1.1
       '@types/fs-extra': 8.0.1
       '@types/js-yaml': 3.12.1
       '@types/lodash.has': 4.5.6
@@ -12170,7 +12091,7 @@ packages:
       tar: 5.0.5
       terminal-link: 2.0.0
       testdouble: 3.12.4
-      ts-node: /ts-node/8.5.3/typescript@3.7.2
+      ts-node: /ts-node/8.5.4/typescript@3.7.2
       tslib: 1.10.0
       tslint: /tslint/5.20.1/typescript@3.7.2
       typescript: 3.7.2
@@ -12191,7 +12112,7 @@ packages:
       jju: 1.4.0
       lodash.once: 4.1.1
       npm-check-updates: 3.2.2
-      tslint: 5.20.1
+      tslint: /tslint/5.20.1/typescript@3.7.2
       typescript: 3.7.2
       yargs: 14.2.2
     dev: false
@@ -12218,7 +12139,6 @@ packages:
     version: 0.0.0
   'file:projects/subscriptions.tgz':
     dependencies:
-      '@reshuffle/interfaces-node-client': 0.5.1
       '@types/node': 10.17.6
       '@types/react': 16.9.13
       '@types/sinon': 7.5.1
@@ -12229,12 +12149,12 @@ packages:
       react: 16.12.0
       rxjs: 6.5.3
       sinon: 7.5.0
-      tslint: 5.20.1
+      tslint: /tslint/5.20.1/typescript@3.7.2
       typescript: 3.7.2
     dev: false
     name: '@rush-temp/subscriptions'
     resolution:
-      integrity: sha512-bucQFMbFgRYKm6fRyMaX8yfdFJhcgDt0jzQSKyiMp3TPDDgPnIXFDcdzTlxZJInFV4g7YRcnODowhLfdP7D69g==
+      integrity: sha512-R8YCa0e+QviZ9qTtvDd4Dlyy3rzEHE9RJBMJwASWU+t9EGAFkFMIf/Ai486cwhNnqgOCGpCixJl8HoyaK6Cm5w==
       tarball: 'file:projects/subscriptions.tgz'
     version: 0.0.0
   'file:projects/utils-subprocess.tgz':
@@ -12268,8 +12188,6 @@ specifiers:
   '@oclif/plugin-help': ^2.2.1
   '@oclif/tslint': ^3.1.1
   '@octokit/rest': ^16.35.0
-  '@reshuffle/interfaces-koa-server': 0.5.1
-  '@reshuffle/interfaces-node-client': 0.5.1
   '@rush-temp/app-testsuite': 'file:./projects/app-testsuite.tgz'
   '@rush-temp/auth': 'file:./projects/auth.tgz'
   '@rush-temp/code-transform': 'file:./projects/code-transform.tgz'


### PR DESCRIPTION
Avoid using published @reshuffle/interfaces packages, and instead rely
on the generated files to ensure issues are spotted earlier

Any update to the interfaces version requires from all users to run
./scripts/generate_interfaces to updated @reshuffle/interfaces packages