### PR TITLE
Force app-testsuite to create-react-app with npm

### DIFF
--- a/app-testsuite/src/run.ts
+++ b/app-testsuite/src/run.ts
@@ -182,7 +182,7 @@ class App {
 
   public async create() {
     log('Creating react app');
-    await spawn('npx', ['create-react-app', this.appName], {
+    await spawn('npx', ['create-react-app', '--use-npm', this.appName], {
       cwd: this.testDir,
       stdio: 'inherit',
       shell,


### PR DESCRIPTION
When using yarn it takes longer to install the @reshuffle packages since
it forces a full reinstall