### PR TITLE
Extract 'backend' directory constant to a single package

### DIFF
--- a/build-utils/package.json
+++ b/build-utils/package.json
@@ -15,6 +15,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@reshuffle/project-config": "0.1.0",
     "@reshuffle/utils-subprocess": "0.0.2",
     "any-shell-escape": "^0.1.1",
     "express": "^4.17.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -50,6 +50,7 @@
     "@oclif/parser": "^3.8.4",
     "@oclif/plugin-help": "^2.2.3",
     "@reshuffle/build-utils": "^0.1.0",
+    "@reshuffle/project-config": "0.1.0",
     "@reshuffle/utils-subprocess": "0.0.2",
     "any-shell-escape": "^0.1.1",
     "chalk": "^2.4.2",

--- a/cli/src/test/fake_lycan.ts
+++ b/cli/src/test/fake_lycan.ts
@@ -9,6 +9,7 @@ import { env as processEnv } from 'process';
 import * as path from 'path';
 import { remove, mkdirp } from 'fs-extra';
 import shellEscape from 'any-shell-escape';
+import { config } from '@reshuffle/project-config';
 
 export interface UploadSuccess {
   ok: true;
@@ -56,8 +57,8 @@ projects:
 `;
     await writeFile(t.context.configPath, t.context.projectConfig);
     await mkdir(t.context.projectDir);
-    await mkdir(path.join(t.context.projectDir, 'backend'));
-    await writeFile(path.join(t.context.projectDir, 'backend', 'index.js'), '');
+    await mkdir(path.join(t.context.projectDir, config.backendDirectory));
+    await writeFile(path.join(t.context.projectDir, config.backendDirectory, 'index.js'), '');
     await mkdirp(path.join(t.context.projectDir, 'node_modules/.bin'));
     await writeFile(path.join(t.context.projectDir, 'node_modules/.bin/babel'), 'echo built', { mode: 0o755 });
     await writeFile(path.join(t.context.projectDir, 'package.json'), JSON.stringify({

--- a/code-transform/package.json
+++ b/code-transform/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/parser": "^7.7.7",
+    "@reshuffle/project-config": "0.1.0",
     "babel-plugin-macros": "^2.8.0"
   },
   "devDependencies": {

--- a/code-transform/src/macro.ts
+++ b/code-transform/src/macro.ts
@@ -3,6 +3,7 @@ import { parse } from '@babel/parser';
 // not using since not sure if babel.types is the very same babel.types or a different version
 // import * as t from '@babel/types';
 import * as babelTypes from '@babel/types';
+import { config } from '@reshuffle/project-config';
 import { getFunctionName, isExposedStatement, isTypeScriptGeneratedExport } from './common';
 import { readFileSync } from 'fs';
 import path from 'path';
@@ -85,7 +86,7 @@ function exposeMacro({ state, babel }: { state: MacrosPluginPass, babel: MacrosB
       const names = node.specifiers.map((specifier) => specifier.local.name);
       const dir = path.dirname(state.filename);
       const importedFile = path.join(dir, node.source.value);
-      const backendRoot = path.join(state.file.opts.root, 'backend');
+      const backendRoot = path.join(state.file.opts.root, config.backendDirectory);
       const relative = path.relative(backendRoot, importedFile);
       const isSubPath = relative && !relative.startsWith('..') && !path.isAbsolute(relative);
       if (isSubPath) {

--- a/common/changes/@reshuffle/build-utils/project-config-extract_2020-01-08-15-39.json
+++ b/common/changes/@reshuffle/build-utils/project-config-extract_2020-01-08-15-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@reshuffle/build-utils",
+      "type": "none"
+    }
+  ],
+  "packageName": "@reshuffle/build-utils",
+  "email": "vladimir@reshuffle.com"
+}

--- a/common/changes/@reshuffle/code-transform/project-config-extract_2020-01-08-15-39.json
+++ b/common/changes/@reshuffle/code-transform/project-config-extract_2020-01-08-15-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@reshuffle/code-transform",
+      "type": "none"
+    }
+  ],
+  "packageName": "@reshuffle/code-transform",
+  "email": "vladimir@reshuffle.com"
+}

--- a/common/changes/@reshuffle/local-proxy/project-config-extract_2020-01-08-15-39.json
+++ b/common/changes/@reshuffle/local-proxy/project-config-extract_2020-01-08-15-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@reshuffle/local-proxy",
+      "type": "none"
+    }
+  ],
+  "packageName": "@reshuffle/local-proxy",
+  "email": "vladimir@reshuffle.com"
+}

--- a/common/changes/@reshuffle/project-config/project-config-extract_2020-01-08-15-39.json
+++ b/common/changes/@reshuffle/project-config/project-config-extract_2020-01-08-15-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@reshuffle/project-config",
+      "comment": "Initial",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@reshuffle/project-config",
+  "email": "vladimir@reshuffle.com"
+}

--- a/common/changes/@reshuffle/server-function/project-config-extract_2020-01-16-12-21.json
+++ b/common/changes/@reshuffle/server-function/project-config-extract_2020-01-16-12-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@reshuffle/server-function",
+      "type": "none"
+    }
+  ],
+  "packageName": "@reshuffle/server-function",
+  "email": "vladimir@reshuffle.com"
+}

--- a/common/changes/reshuffle/project-config-extract_2020-01-08-15-39.json
+++ b/common/changes/reshuffle/project-config-extract_2020-01-08-15-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "reshuffle",
+      "type": "none"
+    }
+  ],
+  "packageName": "reshuffle",
+  "email": "vladimir@reshuffle.com"
+}

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -28,6 +28,7 @@ dependencies:
   '@rush-temp/leveldb-server': 'file:projects/leveldb-server.tgz'
   '@rush-temp/local-proxy': 'file:projects/local-proxy.tgz'
   '@rush-temp/passport': 'file:projects/passport.tgz'
+  '@rush-temp/project-config': 'file:projects/project-config.tgz'
   '@rush-temp/react-app': 'file:projects/react-app.tgz'
   '@rush-temp/react-auth': 'file:projects/react-auth.tgz'
   '@rush-temp/react-storage': 'file:projects/react-storage.tgz'
@@ -12303,7 +12304,7 @@ packages:
     dev: false
     name: '@rush-temp/build-utils'
     resolution:
-      integrity: sha512-Uble3oXock20XL0h5zu78TPgMR85BbUwi3IYUQnPqSPofbUNkIuk1LOnO2xRnJEhZI3mvlgIiTGNt8ZKleGGIA==
+      integrity: sha512-x5m63h4RSX8SrQDvwIo1aHodozdojYquSlEl4KTPUzz8MVHUJiuW16oezBJBDSAPQMrZHSgMY5SgEZ9K0RPW9A==
       tarball: 'file:projects/build-utils.tgz'
     version: 0.0.0
   'file:projects/code-transform.tgz':
@@ -12322,7 +12323,7 @@ packages:
     dev: false
     name: '@rush-temp/code-transform'
     resolution:
-      integrity: sha512-s3U8zFk9TR8SvRsqHWXWT63a9NvJ+UWl3fJ/T1SFQAF39CI/c7648O1Erkkjoh3geQse4ys3McgJ1KAY4Wh/Fg==
+      integrity: sha512-aLYXghWd3WV80Z2u66HrZqXFwnTANkIgHS1EMABok2qwC42pPcvruB6/TIcnGw2vssvGddHtIsgEyhAvSfpLZA==
       tarball: 'file:projects/code-transform.tgz'
     version: 0.0.0
   'file:projects/db-testsuite.tgz':
@@ -12510,7 +12511,7 @@ packages:
     dev: false
     name: '@rush-temp/local-proxy'
     resolution:
-      integrity: sha512-zO0NKppGKTAutD+WVCsUUgbHPx4KX1s2e+MTxLYBB8sybzwmk480nMeYU7CCIaeFeDjWgCcDg2nfhXzqlAlo/w==
+      integrity: sha512-xuONmCYSPY5Fp8Z4rBAAAnOMpKGtBc9yptvomCGkga73FEpT8AhG87Q3WdrU9Gn0m+RQQBN+i6thr6+4JaMITg==
       tarball: 'file:projects/local-proxy.tgz'
     version: 0.0.0
   'file:projects/passport.tgz':
@@ -12538,6 +12539,15 @@ packages:
     resolution:
       integrity: sha512-R+Ort1jAWPJJwFkZD0YMPKVHrWCcSZgEtycm2aFBSwWiEjiPvq2DL5kEvU4f8/lM6wSGuys9R/yEr49kr9QSqQ==
       tarball: 'file:projects/passport.tgz'
+    version: 0.0.0
+  'file:projects/project-config.tgz':
+    dependencies:
+      typescript: 3.7.4
+    dev: false
+    name: '@rush-temp/project-config'
+    resolution:
+      integrity: sha512-1NLohnVhdoBhHtShc+XrqcjxIgoCLHOfzCKFWZEWj9iVnD7dy2k2tUYsNwHJZW148WUiE4Looe7RErDiTbUYaQ==
+      tarball: 'file:projects/project-config.tgz'
     version: 0.0.0
   'file:projects/react-app.tgz':
     dependencies:
@@ -12652,7 +12662,7 @@ packages:
     dev: false
     name: '@rush-temp/reshuffle'
     resolution:
-      integrity: sha512-/2L9Ea5noxxxFxhpVbfrtZlHgkSRwLl2SNIZnj7vnqrJpeM+39+O7Z2oSsnu99l8shq7AOiNWOM4w1YXfPaHRg==
+      integrity: sha512-vYjLOZr4eQ+QYia3s0S87AcJdQ0BampAHGe7BOe+vS0iZOc68tPmRIpfJWsOv+zEz4kuoF5CmynGKk57WqqZVA==
       tarball: 'file:projects/reshuffle.tgz'
     version: 0.0.0
   'file:projects/rush-update.tgz':
@@ -12688,7 +12698,7 @@ packages:
     dev: false
     name: '@rush-temp/server-function'
     resolution:
-      integrity: sha512-Nl9m9x5UGmVJ1Z5NzuE3tMiIMl47nyZOQz95utV0AK4Cs8RcFbOpen6WQbfakK9sZDPEQEid+wiWclHVxfSHbA==
+      integrity: sha512-JvEW4UDlm4xpWMrjHA0Jsn5j/MO7IjjZ2X5OQod1Fav4R7dU6RkpPlsX7xGSwX9SBuImovs8SHCBhvmrZp0TDw==
       tarball: 'file:projects/server-function.tgz'
     version: 0.0.0
   'file:projects/storage.tgz':
@@ -12775,6 +12785,7 @@ specifiers:
   '@rush-temp/leveldb-server': 'file:./projects/leveldb-server.tgz'
   '@rush-temp/local-proxy': 'file:./projects/local-proxy.tgz'
   '@rush-temp/passport': 'file:./projects/passport.tgz'
+  '@rush-temp/project-config': 'file:./projects/project-config.tgz'
   '@rush-temp/react-app': 'file:./projects/react-app.tgz'
   '@rush-temp/react-auth': 'file:./projects/react-auth.tgz'
   '@rush-temp/react-storage': 'file:./projects/react-storage.tgz'

--- a/local-proxy/package.json
+++ b/local-proxy/package.json
@@ -23,6 +23,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.7.5",
     "@reshuffle/interfaces-koa-server": "0.5.1",
     "@reshuffle/leveldb-server": "0.1.3",
+    "@reshuffle/project-config": "0.1.0",
     "@types/express": "^4.17.1",
     "address": "^1.1.2",
     "dotenv": "^8.2.0",

--- a/local-proxy/src/index.ts
+++ b/local-proxy/src/index.ts
@@ -6,6 +6,7 @@ import nanoid from 'nanoid';
 import { EventEmitter } from 'events';
 import net, { AddressInfo } from 'net';
 import address from 'address';
+import { config } from '@reshuffle/project-config';
 
 const isTestEnv = process.env.NODE_ENV === 'test';
 
@@ -71,7 +72,7 @@ export function startProxy(
 
   nodemon({
     watch: [
-      path.join(rootDir, 'backend'),
+      path.join(rootDir, config.backendDirectory),
     ],
     script: path.join(__dirname, 'server.js'),
     delay: 100,
@@ -82,7 +83,7 @@ export function startProxy(
       // A '$PROJECT/.reshuffle' directory for hiding temporarily compiled assets and db
       RESHUFFLE_TMP_DIR: path.resolve(rootDir, '.reshuffle'),
       // The '$PROJECT/backend' directory containing @exposed functions and _handler.js
-      RESHUFFLE_DEV_SERVER_BASE_REQUIRE_PATH: path.resolve(rootDir, 'backend'),
+      RESHUFFLE_DEV_SERVER_BASE_REQUIRE_PATH: path.resolve(rootDir, config.backendDirectory),
       // The '$PROJECT' directory itself
       RESHUFFLE_DEV_SERVER_ROOT_DIR: rootDir,
       RESHUFFLE_DEV_SERVER_LOCAL_TOKEN: localToken,

--- a/local-proxy/src/test/setupHooks.ts
+++ b/local-proxy/src/test/setupHooks.ts
@@ -8,6 +8,7 @@ import { AddressInfo } from 'net';
 import { setupProxy } from '../index';
 import { copy, remove } from 'fs-extra';
 import nodemon from 'nodemon';
+import { config } from '@reshuffle/project-config';
 
 export interface LocalProxyTestInterface {
   port: number;
@@ -24,7 +25,7 @@ export function setupTestHooks(test: TestInterface<LocalProxyTestInterface>) {
     const workdir = await fs.mkdtemp(`${tmpdir()}/.reshuffle-local-proxy-test`, 'utf8');
     t.context.workdir = workdir;
     await copy(path.join(__dirname, 'fixture'), workdir);
-    setupProxy(path.join(workdir, 'backend'))(app);
+    setupProxy(path.join(workdir, config.backendDirectory))(app);
     t.context.stderr = [];
     t.context.stdout = [];
     nodemon.on('readable', function(this: any) {

--- a/project-config/package.json
+++ b/project-config/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@reshuffle/project-config",
+  "version": "0.1.0",
+  "description": "Project configuration constants across projects",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "lint": "eslint -c ../common/.eslintrc.json --ext .ts src",
+    "test": "echo \"static constants with no tests\""
+  },
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^3.7.4"
+  }
+}

--- a/project-config/src/index.ts
+++ b/project-config/src/index.ts
@@ -1,0 +1,4 @@
+export const config = {
+  // TODO: support a different directory using process.env or package.json
+  backendDirectory: 'backend',
+};

--- a/project-config/tsconfig.json
+++ b/project-config/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../common/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/rush.json
+++ b/rush.json
@@ -458,6 +458,11 @@
         "packageName": "@reshuffle/labs-db-iterator",
         "projectFolder": "labs/db-iterator",
         "shouldPublish": true
+    },
+    {
+        "packageName": "@reshuffle/project-config",
+        "projectFolder": "project-config",
+        "shouldPublish": true
     }
   ]
 }

--- a/server-function/package.json
+++ b/server-function/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "@reshuffle/auth": "0.0.1",
+    "@reshuffle/project-config": "0.1.0",
     "@types/express": "^4.17.2",
     "express": "^4.17.1",
     "lodash.once": "^4.1.1",

--- a/server-function/src/serveBinaris.ts
+++ b/server-function/src/serveBinaris.ts
@@ -4,11 +4,12 @@ import http from 'http';
 import once from 'lodash.once';
 import { getHTTPHandler } from './handler';
 import { getInvokeHandler } from './invoke';
+import { config } from '@reshuffle/project-config';
 import sourceMapSupport from 'source-map-support';
 // not handling uncaughtException - both local-proxy and runtime expected to handle them
 sourceMapSupport.install({ handleUncaughtExceptions: false, environment: 'node' });
 
-const backendDir = pathResolve('./backend');
+const backendDir = pathResolve(`./${config.backendDirectory}`);
 const buildDir = pathResolve('./build');
 
 const app = express();


### PR DESCRIPTION
Currently backend was shared by convention between local-proxy,
code-transform macro and cli - this change can allow control of the
project structure in the future