### PR TITLE
Use project root as .env file location

### DIFF
--- a/common/changes/@reshuffle/local-proxy/dotenv-location_2020-01-09-15-39.json
+++ b/common/changes/@reshuffle/local-proxy/dotenv-location_2020-01-09-15-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@reshuffle/local-proxy",
+      "comment": "Fix load of project .env",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@reshuffle/local-proxy",
+  "email": "vladimir@reshuffle.com"
+}

--- a/local-proxy/src/index.ts
+++ b/local-proxy/src/index.ts
@@ -76,8 +76,14 @@ export function startProxy(
     script: path.join(__dirname, 'server.js'),
     delay: 100,
     env: {
+      // For a reshuffle project contained in $PROJECT when running the local
+      // serve we expose the following variables:
+      //
+      // A '$PROJECT/.reshuffle' directory for hiding temporarily compiled assets and db
       RESHUFFLE_TMP_DIR: path.resolve(rootDir, '.reshuffle'),
+      // The '$PROJECT/backend' directory containing @exposed functions and _handler.js
       RESHUFFLE_DEV_SERVER_BASE_REQUIRE_PATH: path.resolve(rootDir, 'backend'),
+      // The '$PROJECT' directory itself
       RESHUFFLE_DEV_SERVER_ROOT_DIR: rootDir,
       RESHUFFLE_DEV_SERVER_LOCAL_TOKEN: localToken,
     },

--- a/local-proxy/src/server.ts
+++ b/local-proxy/src/server.ts
@@ -35,7 +35,7 @@ const basePath = envStr('RESHUFFLE_DEV_SERVER_BASE_REQUIRE_PATH');
 const localToken = envStr('RESHUFFLE_DEV_SERVER_LOCAL_TOKEN');
 
 async function loadDotEnv() {
-  const envFile = resolvePath(basePath, '.env');
+  const envFile = resolvePath(rootPath, '.env');
   try {
     const content = await promisify(readFile)(envFile);
     const parsed = dotenv.parse(content);


### PR DESCRIPTION
This does not affect projects using create-react-app, since
create-react-app populates process.env before reaching reshuffle code

Tested using reshuffle-local-server which does not use dotenv before