### PR TITLE
Use event.context with HttpConnector 

### DIFF
--- a/examples/http/HTTPExample.js
+++ b/examples/http/HTTPExample.js
@@ -6,7 +6,7 @@ const connector = new HttpConnector();
 app.register(connector);
 
 app.when(connector.on({'method':'GET','path':'/test'}), (event) => {
-  event.res.end("Hello World!");
+  event.context.res.end("Hello World!");
 });
 
 // the above is syntactically equivalent to:

--- a/examples/http/registerUnregisterHTTPExample.js
+++ b/examples/http/registerUnregisterHTTPExample.js
@@ -10,7 +10,7 @@ app.start();
 app.start();
 
 app.when(connector.on({'method':'GET','path':'/test'}), (event) => {
-  event.res.end('Hello World!');
+  event.context.res.end('Hello World!');
 });
 
 app.restart();

--- a/src/connectors/HttpConnector.ts
+++ b/src/connectors/HttpConnector.ts
@@ -47,7 +47,12 @@ export default class HttpConnector extends BaseHttpConnector<HttpConnectorOption
 
     if (eventConfiguration) {
       console.log('Handling event')
-      handled = this.app ? await this.app.handleEvent(eventConfiguration.id, { req, res }) : false
+      handled = this.app
+        ? await this.app.handleEvent(eventConfiguration.id, {
+            ...eventConfiguration,
+            context: { req, res },
+          })
+        : false
     }
 
     next()


### PR DESCRIPTION
Fix HTTPConnector to call handle with an event that has system attributes under context