### PR TITLE
Allow custom middleware to be added to the express webserver

### DIFF
--- a/src/Reshuffle.ts
+++ b/src/Reshuffle.ts
@@ -43,7 +43,7 @@ export default class Reshuffle {
   private prepareWebServer(): Express {
     if (!this.registry.common.webserver) {
       this.registry.common.webserver = express()
-      this.registry.common.webserver.use(middleware)
+      this.registry.common.webserver.use(this.middleware)
     }
 
     return this.registry.common.webserver

--- a/src/Reshuffle.ts
+++ b/src/Reshuffle.ts
@@ -1,4 +1,4 @@
-import express, { Express, Request, Response, NextFunction } from 'express'
+import express, { Express, Request, Response, NextFunction, RequestHandler } from 'express'
 import { nanoid } from 'nanoid'
 import * as availableConnectors from './connectors'
 import { MemoryStoreAdapter, PersistentStoreAdapter } from './persistency'
@@ -24,6 +24,7 @@ export default class Reshuffle {
   }
   httpServer?: http.Server
   logger: Logger
+  middleware: RequestHandler[] = [ express.json(), express.urlencoded({ extended: true }) ]
 
   constructor(loggerOptions?: LoggerOptions) {
     this.availableConnectors = availableConnectors
@@ -35,10 +36,14 @@ export default class Reshuffle {
     this.logger.info('Reshuffle Initializing')
   }
 
+  addMiddleware(middleware: RequestHandler) {
+    this.middleware.push(middleware)
+  }
+
   private prepareWebServer(): Express {
     if (!this.registry.common.webserver) {
       this.registry.common.webserver = express()
-      this.registry.common.webserver.use(express.json(), express.urlencoded({ extended: true }))
+      this.registry.common.webserver.use(middleware)
     }
 
     return this.registry.common.webserver


### PR DESCRIPTION
It's handy to be able to add middleware to the express webserver in some circumstances. A few examples:
- adding a health check URL (currently hardcoded into `Reshuffle.ts` but could be removed in future)
- adding in custom middleware such as a **`cookie-parser`**

